### PR TITLE
hooks: skip worktree removal when a live Claude session is running

### DIFF
--- a/private_dot_claude/hooks/_common.sh
+++ b/private_dot_claude/hooks/_common.sh
@@ -212,6 +212,48 @@ remove_worktree_branch() {
 	fi
 }
 
+# Sanitize an absolute path the same way Claude does for project config dirs:
+# / -> -, . -> -. So /foo/.claude/worktrees/abc becomes
+# -foo--claude-worktrees-abc. Trailing slashes are stripped first so callers
+# can pass directories with or without one.
+# $1: absolute path
+sanitize_path() {
+	local p="${1%/}"
+	echo "$p" | sed 's|/|-|g; s|\.|-|g'
+}
+
+# Returns 0 (true) if any live Claude session has its cwd inside $wt_dir.
+# Reads ~/.claude/sessions/<PID>.json files (Claude writes one per running
+# session) and verifies the PID is alive — stale files survive crashes, so the
+# liveness check is required.
+#
+# When $exclude_session is non-empty, sessions with that sessionId are skipped.
+# Used by the primary remove path to avoid self-blocking on the very session
+# that triggered the ExitWorktree hook.
+#
+# $1: worktree directory  $2: optional sessionId to exclude
+worktree_has_active_session() {
+	local wt_dir="${1%/}" exclude_session="${2:-}" sessions_dir="$HOME/.claude/sessions"
+	local f cwd pid sid
+	[ -d "$sessions_dir" ] || return 1
+	for f in "$sessions_dir"/*.json; do
+		[ -f "$f" ] || continue
+		cwd=$(jq -r '.cwd // empty' "$f" 2>/dev/null)
+		pid=$(jq -r '.pid // empty' "$f" 2>/dev/null)
+		sid=$(jq -r '.sessionId // empty' "$f" 2>/dev/null)
+		[ -n "$cwd" ] && [ -n "$pid" ] || continue
+		if [ -n "$exclude_session" ] && [ "$sid" = "$exclude_session" ]; then
+			continue
+		fi
+		case "$cwd" in
+			"$wt_dir"|"$wt_dir"/*) ;;
+			*) continue ;;
+		esac
+		kill -0 "$pid" 2>/dev/null && return 0
+	done
+	return 1
+}
+
 # Iterate over $repo/.claude/worktrees/* and remove any that are stale.
 # A worktree is stale when:
 #   - its branch had an upstream and the remote branch is now gone (and, if
@@ -288,9 +330,14 @@ clean_stale_worktrees() {
 		fi
 
 		if [ "$should_clean" = true ]; then
-			log "→ Cleaning stale worktree: $stale_name ($reason)"
-			remove_worktree_branch "$repo" "$stale_dir" "$stale_branch"
-			removed=$((removed + 1))
+			if worktree_has_active_session "$stale_dir"; then
+				log "⏭ Keeping worktree: $stale_name (live Claude session in this dir)"
+				kept=$((kept + 1))
+			else
+				log "→ Cleaning stale worktree: $stale_name ($reason)"
+				remove_worktree_branch "$repo" "$stale_dir" "$stale_branch"
+				removed=$((removed + 1))
+			fi
 		else
 			kept=$((kept + 1))
 		fi

--- a/private_dot_claude/hooks/executable_worktree-create.sh
+++ b/private_dot_claude/hooks/executable_worktree-create.sh
@@ -184,7 +184,6 @@ clean_stale_worktrees "$REPO_ROOT" "$BASE_REF" "$NAME" "no"
 
 # --- symlink auto-memory so all worktrees share the main repo's memory ---
 # Claude sanitizes paths: / -> -, . -> - (so /foo/.claude -> -foo--claude)
-sanitize_path() { echo "$1" | sed 's|/|-|g; s|\.|-|g'; }
 SANITIZED_MAIN=$(sanitize_path "$REPO_ROOT")
 SANITIZED_WT=$(sanitize_path "$WORKTREE_DIR")
 MAIN_MEMORY="$HOME/.claude/projects/$SANITIZED_MAIN/memory"

--- a/private_dot_claude/hooks/executable_worktree-remove.sh
+++ b/private_dot_claude/hooks/executable_worktree-remove.sh
@@ -18,6 +18,12 @@ REPO_ROOT=$(resolve_repo_root "$CLAUDE_PROJECT_DIR")
 WORKTREE_DIR="$REPO_ROOT/.claude/worktrees/$NAME"
 BRANCH="worktree-$NAME"
 
+TRANSCRIPT=$(echo "$INPUT" | jq -r '.transcript_path // empty')
+CURRENT_SESSION=""
+if [ -n "$TRANSCRIPT" ]; then
+	CURRENT_SESSION=$(basename "$TRANSCRIPT" .jsonl)
+fi
+
 setup_logging "[remove]"
 
 echo "" >> "$LOGFILE"
@@ -41,17 +47,6 @@ if ! git -C "$REPO_ROOT" rev-parse --verify HEAD >/dev/null 2>&1; then
 	exit 0
 fi
 
-# In dry-run, the helpers below are already dry-run aware. The only thing
-# left to guard is the project-config rm -rf and the project hook, which we
-# short-circuit by exiting after the cleanup loop.
-if is_dry_run; then
-	log "[dry-run] would remove worktree $NAME (subject to merged-PR check)"
-	log "[dry-run] skipping project-config rm and project hook"
-	update_default_branch "$REPO_ROOT" "$DEFAULT_BRANCH"
-	clean_stale_worktrees "$REPO_ROOT" "$DEFAULT_BRANCH" "$NAME" "yes"
-	exit 0
-fi
-
 # --- check if the branch has unmerged work before removing ---
 SAFE_TO_REMOVE=true
 
@@ -69,6 +64,26 @@ if git -C "$REPO_ROOT" show-ref --verify --quiet "refs/heads/$BRANCH" 2>/dev/nul
 			log "⚠ Branch $BRANCH has $unique_commits unmerged commit(s) and no merge evidence, preserving worktree"
 		fi
 	fi
+fi
+
+if [ "$SAFE_TO_REMOVE" = true ] && worktree_has_active_session "$WORKTREE_DIR" "$CURRENT_SESSION"; then
+	SAFE_TO_REMOVE=false
+	log "⚠ Another live Claude session is running in $NAME, preserving worktree"
+fi
+
+# In dry-run, the helpers below are already dry-run aware. The only thing
+# left to guard is the project-config rm -rf and the project hook, which we
+# short-circuit by exiting after the cleanup loop.
+if is_dry_run; then
+	if [ "$SAFE_TO_REMOVE" = true ]; then
+		log "[dry-run] would remove worktree $NAME"
+	else
+		log "[dry-run] would preserve worktree $NAME"
+	fi
+	log "[dry-run] skipping project-config rm and project hook"
+	update_default_branch "$REPO_ROOT" "$DEFAULT_BRANCH"
+	clean_stale_worktrees "$REPO_ROOT" "$DEFAULT_BRANCH" "$NAME" "yes"
+	exit 0
 fi
 
 if [ "$SAFE_TO_REMOVE" = true ]; then
@@ -95,17 +110,13 @@ if [ "$SAFE_TO_REMOVE" = true ]; then
 	WT_PROJECT=""
 
 	# Try 1: sanitized path (matching Claude's / -> -, . -> - convention)
-	sanitize_path() { echo "$1" | sed 's|/|-|g; s|\.|-|g'; }
 	SANITIZED_WT=$(sanitize_path "$WORKTREE_DIR")
 	[ -d "$HOME/.claude/projects/$SANITIZED_WT" ] && WT_PROJECT="$HOME/.claude/projects/$SANITIZED_WT"
 
 	# Try 2: transcript_path from the payload contains the project dir name
-	if [ -z "$WT_PROJECT" ]; then
-		TRANSCRIPT=$(echo "$INPUT" | jq -r '.transcript_path // empty')
-		if [ -n "$TRANSCRIPT" ]; then
-			PROJ_FROM_TRANSCRIPT=$(echo "$TRANSCRIPT" | sed 's|.*/.claude/projects/||; s|/.*||')
-			[ -d "$HOME/.claude/projects/$PROJ_FROM_TRANSCRIPT" ] && WT_PROJECT="$HOME/.claude/projects/$PROJ_FROM_TRANSCRIPT"
-		fi
+	if [ -z "$WT_PROJECT" ] && [ -n "$TRANSCRIPT" ]; then
+		PROJ_FROM_TRANSCRIPT=$(echo "$TRANSCRIPT" | sed 's|.*/.claude/projects/||; s|/.*||')
+		[ -d "$HOME/.claude/projects/$PROJ_FROM_TRANSCRIPT" ] && WT_PROJECT="$HOME/.claude/projects/$PROJ_FROM_TRANSCRIPT"
 	fi
 
 	# Try 3: scan sessions-index.json for matching originalPath


### PR DESCRIPTION
## Summary
- Reads `~/.claude/sessions/<PID>.json` (Claude writes one per running session with `cwd`, `pid`, `sessionId`) and verifies the PID is alive — definitive proof of an in-use worktree, no mtime guessing.
- Wires the check into `clean_stale_worktrees` (opportunistic loop now skips live worktrees) and the primary `worktree-remove` path (excludes the current session via `transcript_path` so `ExitWorktree` doesn't self-block).
- Lifts `sanitize_path` into `_common.sh` (was duplicated in both hooks).

## Test plan
- [x] `bash -n` syntax check on all three hook files
- [x] Helper unit-tested against live sessions: detects current session as ACTIVE, returns inactive when current session is excluded, inactive for non-existent paths, ACTIVE for another live worktree
- [x] Dry-run remove of current worktree with `transcript_path`: previews `would remove`
- [x] Dry-run remove of current worktree without `transcript_path`: detects this very session and previews `would preserve`
- [x] `shellcheck` clean (only pre-existing SC1091 source-path notes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)