### PR TITLE
zshrc: drop openclaw from skills-add agent list

### DIFF
--- a/dot_zshrc
+++ b/dot_zshrc
@@ -348,7 +348,7 @@ if command_exists bunx; then
   # Add a skill and propagate via chezmoi in one shot.
   # Usage: skills-add <source> [--skill <name> ...]
   skills-add() {
-      bunx skills add "$@" --agent claude-code --agent codex --agent gemini-cli --agent github-copilot --agent opencode --agent openclaw -g -y || return
+      bunx skills add "$@" --agent claude-code --agent codex --agent gemini-cli --agent github-copilot --agent opencode -g -y || return
       skills-update
   }
 fi


### PR DESCRIPTION
## Summary
- Removes `--agent openclaw` from `skills-add` in `dot_zshrc` so it matches the `AGENTS` array in `run_after_update-skills.sh`.
- Without this, fresh `skills-add` invocations wire openclaw, then the next `chezmoi apply` unwires it as an "extra agent" (lines 132-184 of the hook).

## Test plan
- [ ] `chezmoi apply` does not flag `dot_zshrc` as drifted
- [ ] `skills-add <repo> --skill <name>` wires only the five agents in the hook's `AGENTS` list

🤖 Generated with [Claude Code](https://claude.com/claude-code)