### PR TITLE
zshrc: preserve claude exit status through reset-term

### DIFF
--- a/dot_zshrc
+++ b/dot_zshrc
@@ -480,6 +480,8 @@ reset-term() {
 if command_exists claude; then
   claude() {
       command claude "$@"
+      local rc=$?
       reset-term
+      return $rc
   }
 fi


### PR DESCRIPTION
## Summary
- The \`claude\` zsh wrapper appended \`reset-term\` after \`command claude\`, so the function's exit status was \`reset-term\`'s, masking real failures with 0 (or vice versa).
- Capture \`\$?\` immediately after the binary and \`return\` it once \`reset-term\` has run.

## Test plan
- [ ] \`source ~/.zshrc\` then \`claude --version && echo ok\` prints \`ok\`
- [ ] \`claude --bogus-flag; echo \$?\` reports a non-zero status

🤖 Generated with [Claude Code](https://claude.com/claude-code)