### PR TITLE
zshrc: auto-append skills-add args to wishlist

### DIFF
--- a/dot_zshrc
+++ b/dot_zshrc
@@ -380,7 +380,15 @@ if command_exists bunx; then
           --agent gemini-cli \
           --agent github-copilot \
           --agent opencode \
-          -g -y
+          -g -y || return
+
+      local wishlist="$HOME/.agents/skills.wishlist"
+      local entry="$*"
+      if [[ ! -f "$wishlist" ]] || ! grep -qFx -- "$entry" "$wishlist"; then
+          echo "$entry" >> "$wishlist"
+          echo "[skills-add] appended to $wishlist"
+          echo "[skills-add] run: chezmoi re-add $wishlist && cd \$(chezmoi source-path) && git status"
+      fi
   }
 
   # Install the curated set of agent skills from ~/.agents/skills.wishlist


### PR DESCRIPTION
## Summary
- After a successful `bunx skills add`, append the arg line to `~/.agents/skills.wishlist` (dedup via `grep -Fx`).
- `|| return` on the bunx call prevents wishlist pollution when install fails.
- Print a follow-up hint with the `chezmoi re-add` command so the wishlist edit gets back into source control.

Closes #9

## Test plan
- [x] success path: appends entry, prints hint
- [x] idempotency: re-running same args is a no-op
- [x] failure path: bunx non-zero rc leaves wishlist untouched and propagates the exit code

🤖 Generated with [Claude Code](https://claude.com/claude-code)