### PR TITLE
zshenv: export ALLTUNER_CF_CONFIG pointing at synced secrets

### DIFF
--- a/dot_zshenv
+++ b/dot_zshenv
@@ -14,6 +14,9 @@ export HOMEBREW_CASK_OPTS="--no-quarantine"
 # The script falls back to ~/.config/expose.env when this is unset.
 export EXPOSE_CONFIG="$HOME/sync/secrets/expose.env"
 
+# alltuner cloudflare API config lives in synced secrets.
+export ALLTUNER_CF_CONFIG="$HOME/sync/secrets/alltuner/cloudflare.json"
+
 # Telemetry opt-outs (https://donottrack.sh/). Universal flag plus per-tool
 # variables for CLIs that don't honor DO_NOT_TRACK. Set in zshenv so they
 # also apply to non-interactive shells (scripts, launchd, ssh exec).


### PR DESCRIPTION
## Summary
- Add `ALLTUNER_CF_CONFIG` export to `dot_zshenv` so all zsh shells (login, interactive, non-interactive — scripts, launchd, ssh exec) see it.
- Mirrors the `EXPOSE_CONFIG` pattern from #15: pointer to a synced-secrets file, no secret values in the repo.

## Test plan
- [ ] `chezmoi apply` and open a new shell; `printenv ALLTUNER_CF_CONFIG` returns the synced path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)