### PR TITLE
alltuner: symlink ~/.config/alltuner into synced secrets

### DIFF
--- a/dot_zshenv
+++ b/dot_zshenv
@@ -14,9 +14,6 @@ export HOMEBREW_CASK_OPTS="--no-quarantine"
 # The script falls back to ~/.config/expose.env when this is unset.
 export EXPOSE_CONFIG="$HOME/sync/secrets/expose.env"
 
-# alltuner cloudflare API config lives in synced secrets.
-export ALLTUNER_CF_CONFIG="$HOME/sync/secrets/alltuner/cloudflare.json"
-
 # Telemetry opt-outs (https://donottrack.sh/). Universal flag plus per-tool
 # variables for CLIs that don't honor DO_NOT_TRACK. Set in zshenv so they
 # also apply to non-interactive shells (scripts, launchd, ssh exec).

--- a/private_dot_config/symlink_alltuner
+++ b/private_dot_config/symlink_alltuner
@@ -1,1 +1,1 @@
-~/sync/secrets/alltuner-cli-config
+../sync/secrets/alltuner-cli-config

--- a/private_dot_config/symlink_alltuner
+++ b/private_dot_config/symlink_alltuner
@@ -1,0 +1,1 @@
+~/sync/secrets/alltuner-cli-config


### PR DESCRIPTION
## Summary
- Ship `~/.config/alltuner` as a chezmoi-managed symlink to `~/sync/secrets/alltuner-cli-config`.
- Drop `ALLTUNER_CF_CONFIG` from `dot_zshenv` — the symlink puts every config file under its canonical path, so the env var is redundant.

The symlink target is dangling until sync populates it. That's fine: chezmoi creates the link unconditionally, consumers get ENOENT on missing files until sync lands. `run_after_zz-install-alltuner.sh` only runs `uv tool install`, doesn't read config, so bootstrap ordering isn't affected.

## Test plan
- [x] `chezmoi diff` against this source shows `.config/alltuner` flipping from dir (mode 40755) → symlink (120000) pointing at `~/sync/secrets/alltuner-cli-config`
- [ ] On merge: pull in `~/.local/share/chezmoi`, `chezmoi apply`, verify `readlink ~/.config/alltuner` returns the expected target
- [ ] Populate `~/sync/secrets/alltuner-cli-config` via the sync mechanism and confirm `alltuner` CLI picks up cloudflare/infisical/umami configs

🤖 Generated with [Claude Code](https://claude.com/claude-code)