### PR TITLE
zshrc: move telemetry opt-outs out of zshenv

### DIFF
--- a/dot_zshenv
+++ b/dot_zshenv
@@ -13,15 +13,3 @@ export HOMEBREW_CASK_OPTS="--no-quarantine"
 # expose: config lives in synced secrets (server hostname is private).
 # The script falls back to ~/.config/expose.env when this is unset.
 export EXPOSE_CONFIG="$HOME/sync/secrets/expose.env"
-
-# Telemetry opt-outs (https://donottrack.sh/). Universal flag plus per-tool
-# variables for CLIs that don't honor DO_NOT_TRACK. Set in zshenv so they
-# also apply to non-interactive shells (scripts, launchd, ssh exec).
-# Homebrew uses HOMEBREW_NO_ANALYTICS, set alongside the rest of brew config in .zshrc.
-export DO_NOT_TRACK=1
-export DOTNET_CLI_TELEMETRY_OPTOUT=1
-export SAM_CLI_TELEMETRY=0
-export AZURE_CORE_COLLECT_TELEMETRY=0
-export GATSBY_TELEMETRY_DISABLED=1
-export STNOUPGRADE=1
-export CLOUDSDK_CORE_DISABLE_USAGE_REPORTING=true

--- a/dot_zshrc
+++ b/dot_zshrc
@@ -73,6 +73,22 @@ fi
 
 
 ###########################################################
+# Telemetry Opt-outs                                      #
+###########################################################
+# https://donottrack.sh/ — universal flag plus per-tool overrides for CLIs
+# that don't honor DO_NOT_TRACK. Kept in .zshrc (interactive shells only) so
+# subshells spawned by `claude` don't inherit DO_NOT_TRACK=1 from a global
+# default and opt claude out of telemetry against our wishes.
+export DO_NOT_TRACK=1
+export DOTNET_CLI_TELEMETRY_OPTOUT=1
+export SAM_CLI_TELEMETRY=0
+export AZURE_CORE_COLLECT_TELEMETRY=0
+export GATSBY_TELEMETRY_DISABLED=1
+export STNOUPGRADE=1
+export CLOUDSDK_CORE_DISABLE_USAGE_REPORTING=true
+
+
+###########################################################
 # History Configuration                                   #
 ###########################################################
 
@@ -485,7 +501,9 @@ reset-term() {
 }
 
 # Ghostty occasionally doesn't receive the keyboard-mode pop on `claude` exit.
-# Also scrub DO_NOT_TRACK so claude isn't opted out via the global zshenv default.
+# Also scrub DO_NOT_TRACK so claude itself isn't opted out via the interactive
+# default above (subshells spawned by claude don't source .zshrc, so they're
+# already clean).
 if command_exists claude; then
   claude() {
       env -u DO_NOT_TRACK command claude "$@"


### PR DESCRIPTION
## Summary

- Subshells spawned by `claude` (e.g. `!env` in the TUI) re-source `~/.zshenv` on every invocation, so `DO_NOT_TRACK=1` kept leaking back in even though the `claude()` wrapper scrubs it from claude's own process.
- Move `DO_NOT_TRACK` and the per-tool telemetry vars (`DOTNET_CLI_TELEMETRY_OPTOUT`, `SAM_CLI_TELEMETRY`, `AZURE_CORE_COLLECT_TELEMETRY`, `GATSBY_TELEMETRY_DISABLED`, `STNOUPGRADE`, `CLOUDSDK_CORE_DISABLE_USAGE_REPORTING`) from `dot_zshenv` to `dot_zshrc` so they only apply to interactive shells. Claude's subshells now stay clean.
- Trade-off: non-interactive contexts (scripts, launchd, `ssh exec`) no longer get these opt-outs. `HOMEBREW_NO_ANALYTICS` already lived in `dot_zshrc`, so the precedent is established.

## Test plan

- [ ] `chezmoi apply` cleanly on tamarind
- [ ] Open new ghostty/iTerm window → `env | grep -E 'DO_NOT_TRACK|DOTNET_CLI_TELEMETRY_OPTOUT'` returns the expected exports
- [ ] Launch `claude`, run `!env | grep DO_NOT_TRACK` inside → should return **nothing**
- [ ] `ssh tamarind 'env | grep DO_NOT_TRACK'` (non-interactive) → should return **nothing** (this is the intended change in behavior)