### PR TITLE
bun: enable isolated linker + global virtual store

### DIFF
--- a/private_dot_config/dot_bunfig.toml
+++ b/private_dot_config/dot_bunfig.toml
@@ -1,4 +1,6 @@
 [install]
+linker = "isolated"
+globalStore = true
 minimumReleaseAge = 172800
 minimumReleaseAgeExcludes = [
   "@alltuner/vibetuner",


### PR DESCRIPTION
## Summary

Adds `~/.config/.bunfig.toml` enabling Bun's isolated linker with the global virtual store (Bun 1.3.14+). Cross-project `node_modules` contents get deduplicated via symlinks into a per-machine store, with ~7× faster warm installs.

## Caveat

Projects whose code imports transitively-hoisted deps without declaring them in `package.json` will fail to build under isolated mode. This is the case for vibetuner-scaffolded projects today — tracked in [alltuner/vibetuner#1796](https://github.com/alltuner/vibetuner/issues/1796). Affected projects can opt out per-project with a local `bunfig.toml` setting `linker = "hoisted"`.

Verified failure mode via smoke test on `bulletin` (htmx.org / tailwindcss CLI not declared, both hoisted from `@alltuner/vibetuner*`).

## Test plan

- [ ] `chezmoi apply` on both hosts
- [ ] `cat ~/.config/.bunfig.toml` shows the new config
- [ ] A non-vibetuner project (e.g. `devtuner.com`) does a clean `bun install` successfully under isolated mode
- [ ] Vibetuner-scaffolded projects get a project-local `linker = "hoisted"` override until alltuner/vibetuner#1796 ships

Closes #19