### PR TITLE
uv: 2-day cooldown on package versions, with vibetuner excluded

### DIFF
--- a/private_dot_config/uv/uv.toml
+++ b/private_dot_config/uv/uv.toml
@@ -1,0 +1,4 @@
+exclude-newer = "2 days"
+
+[exclude-newer-package]
+vibetuner = false


### PR DESCRIPTION
## Summary

Adds `~/.config/uv/uv.toml` setting `exclude-newer = "2 days"` globally — a 2-day rolling cooldown on package versions. Defense against supply-chain attacks where malicious releases are typically yanked within hours; 2 days filters most of them before they ever resolve.

Internal package `vibetuner` is excluded (`vibetuner = false` in `exclude-newer-package`) so its updates aren't delayed — published and consumed by me, trusted by construction.

## Test plan

- [ ] `chezmoi apply` lands the file
- [ ] `cd $(mktemp -d) && uv pip install --dry-run requests` resolves to a version at least 2 days old
- [ ] `uv pip install --dry-run vibetuner` resolves to latest (cooldown bypassed for excluded package)

## Out of scope

- bun cooldown — depends on #21 (which sets up the shared bunfig); separate follow-up.
- npm cooldown — needs a strategy for keeping the npm auth token out of this public repo.
- cargo cooldown — no native support yet; waiting on RFC #3923.

Refs #20