### PR TITLE
bun: 2-day cooldown on package versions, with vibetuner packages excluded

### DIFF
--- a/private_dot_config/dot_bunfig.toml
+++ b/private_dot_config/dot_bunfig.toml
@@ -1,0 +1,6 @@
+[install]
+minimumReleaseAge = 172800
+minimumReleaseAgeExcludes = [
+  "@alltuner/vibetuner",
+  "@alltuner/vibetuner-jinja",
+]


### PR DESCRIPTION
## Summary

Adds `~/.config/.bunfig.toml` with `minimumReleaseAge = 172800` (2 days) globally — a 2-day rolling cooldown on package versions. Defense against supply-chain attacks where malicious releases are typically yanked within hours.

Internal packages `@alltuner/vibetuner` and `@alltuner/vibetuner-jinja` are listed in `minimumReleaseAgeExcludes` so their updates aren't artificially delayed — published and consumed by me, trusted by construction.

Bun does not support wildcard or scope-glob matching ([test suite confirms](https://github.com/oven-sh/bun/blob/main/test/cli/install/minimum-release-age.test.ts)) — each package must be listed by exact name.

## Relationship to #21 (isolated linker)

[PR #21](https://github.com/davidpoblador/dotfiles/pull/21) (currently draft) introduces the isolated linker into the same bunfig file. When that lands later, the `[install]` block will need the `linker` and `globalStore` keys added on top — small rebase.

## Test plan

- [ ] `chezmoi apply` lands the file
- [ ] `cd $(mktemp -d) && bun init -y && bun add lodash --dry-run` — confirm resolved version is ≥ 2 days old
- [ ] `bun add @alltuner/vibetuner@latest --dry-run` — confirm cooldown bypassed (latest fetched)

## Out of scope

- bun isolated linker / globalStore — tracked in #21, holding off for now.
- npm cooldown — `~/.npmrc` holds an npm auth token; moving it via `NPM_CONFIG_USERCONFIG` to this public repo would leak the token. Skipped until a chezmoi-template/secret-store strategy is in place. Also: I don't use npm directly today.
- cargo cooldown — not natively supported by cargo. `cargo-cooldown` is a per-invocation wrapper (not transparent), no per-package exclusions. Waiting on [RFC #3923](https://github.com/rust-lang/rfcs/) instead.

Refs #20