### PR TITLE
hooks: add SessionEnd hook to keep main fresh in agent-mode worktrees

### DIFF
--- a/private_dot_claude/hooks/executable_session-end-update-main.sh
+++ b/private_dot_claude/hooks/executable_session-end-update-main.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# ABOUTME: SessionEnd hook — when a Claude session in a git worktree ends,
+# ABOUTME: fetch + fast-forward the parent repo's default branch.
+#
+# Why: `claude agents` / central-coordinator agent-mode worktrees are torn
+# down without firing WorktreeRemove, so the existing update_default_branch
+# step that lives in worktree-remove.sh never runs for them. SessionEnd
+# fires reliably for those sessions, so we use it as the backup signal.
+# Idempotent: doubling up with WorktreeRemove on the normal `claude -w`
+# path is fine — a second `git fetch` is a no-op when already current.
+
+set -euo pipefail
+
+# shellcheck source=_common.sh
+source "$(dirname "$0")/_common.sh"
+
+INPUT=$(cat)
+
+# Prefer the payload's cwd; fall back to CLAUDE_PROJECT_DIR. Either is fine —
+# we just need a path inside the (possibly worktree) repo.
+CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
+[ -n "$CWD" ] || CWD="${CLAUDE_PROJECT_DIR:-}"
+[ -n "$CWD" ] && [ -d "$CWD" ] || exit 0
+
+# Only act when we're inside a *worktree* (not the main checkout). A worktree
+# has its per-worktree GIT_DIR distinct from the shared git_common_dir; in the
+# main checkout those resolve to the same `.git`.
+GIT_DIR=$(git -C "$CWD" rev-parse --git-dir 2>/dev/null) || exit 0
+COMMON_DIR=$(git -C "$CWD" rev-parse --git-common-dir 2>/dev/null) || exit 0
+GIT_DIR_ABS=$(cd "$CWD" && cd "$GIT_DIR" && pwd -P)
+COMMON_DIR_ABS=$(cd "$CWD" && cd "$COMMON_DIR" && pwd -P)
+[ "$GIT_DIR_ABS" != "$COMMON_DIR_ABS" ] || exit 0
+
+# `git worktree list --porcelain` always lists the main worktree first.
+REPO_ROOT=$(git -C "$CWD" worktree list --porcelain 2>/dev/null | head -1 | sed 's/^worktree //')
+[ -n "$REPO_ROOT" ] && [ -d "$REPO_ROOT" ] || exit 0
+
+setup_logging "[session-end]"
+
+NAME=$(basename "$CWD")
+log "--- SessionEnd in worktree: $NAME (repo: $REPO_ROOT) ---"
+log_quiet "    payload: $(jq -c . <<< "$INPUT" 2>/dev/null || echo "$INPUT" | tr '\n' ' ')"
+
+DEFAULT_BRANCH=$(detect_default_branch "$REPO_ROOT")
+if [ -z "$DEFAULT_BRANCH" ]; then
+	log "⚠ Could not determine default branch for $REPO_ROOT"
+	exit 0
+fi
+
+update_default_branch "$REPO_ROOT" "$DEFAULT_BRANCH"
+log "✓ Updated $DEFAULT_BRANCH in $REPO_ROOT"

--- a/private_dot_claude/settings.json
+++ b/private_dot_claude/settings.json
@@ -178,6 +178,16 @@
         ]
       }
     ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/session-end-update-main.sh"
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "Bash",


### PR DESCRIPTION
## Summary

- Adds `~/.claude/hooks/session-end-update-main.sh` (registered under `SessionEnd` in `settings.json`) that, when the session's cwd is inside a git worktree, fast-forwards the parent repo's default branch via the existing `update_default_branch` helper from `_common.sh`.
- Backfills the path that coordinator-spawned `claude agents` worktree sessions take when they tear down: they skip `WorktreeRemove`, so the existing `update_default_branch` step in `worktree-remove.sh` never runs for them. `SessionEnd` fires reliably for those sessions.
- Idempotent on the normal `claude -w` flow — a second `git fetch` is a no-op when already current. Always exits 0 so a transient git failure can't break Claude's session shutdown.

Scope is intentionally narrow: only the `update_default_branch` step. The full removal path (branch delete, dir prune, project-config purge, stale-worktree sweep) still only runs on `WorktreeRemove`.

Closes #24

## Test plan

- [x] `python3 -c "import json; json.load(...)"` on `settings.json` — valid JSON
- [x] `/bin/bash -n` on the new hook — bash 3.2 syntax OK (chezmoi runs hooks under macOS `/bin/bash`)
- [x] Smoke test from the main checkout — exits 0 silently, no log entry
- [x] Smoke test from a worktree cwd — logs `[session-end]` block and runs the update path
- [x] Live coordinator-spawned sessions on 2026-05-13 already emit `[session-end]` entries in `/tmp/worktree-hooks-*.log` via the on-disk copy at `~/.claude/hooks/session-end-update-main.sh`; this PR lands the in-tree version so `chezmoi apply` installs it.
- [ ] After merge + `chezmoi apply`, verify the next coordinator-spawned agent teardown logs `✓ Updated <branch> in <repo>` in `/tmp/worktree-hooks-$(date +%Y-%m-%d).log`

🤖 Generated with [Claude Code](https://claude.com/claude-code)