### PR TITLE
hooks: route OSC 7 + log via $CLAUDE_INVOKER_TTY for detached agents

### DIFF
--- a/dot_zshrc
+++ b/dot_zshrc
@@ -504,9 +504,21 @@ reset-term() {
 # Also scrub DO_NOT_TRACK so claude itself isn't opted out via the interactive
 # default above (subshells spawned by claude don't source .zshrc, so they're
 # already clean).
+#
+# Capture this shell's tty path and pass it down as CLAUDE_INVOKER_TTY.
+# Detached agent-team teammates spawned by claude have no controlling tty
+# of their own, so hooks running under them can't write OSC sequences to
+# /dev/tty (those writes silently no-op). The hooks fall back to
+# $CLAUDE_INVOKER_TTY to reach the user's actual terminal — e.g. so
+# WorktreeCreate can update Ghostty's OSC 7 cwd tracking.
 if command_exists claude; then
   claude() {
-      env -u DO_NOT_TRACK command claude "$@"
+      local tty_path
+      if tty_path=$(tty 2>/dev/null); then
+          env -u DO_NOT_TRACK CLAUDE_INVOKER_TTY="$tty_path" command claude "$@"
+      else
+          env -u DO_NOT_TRACK command claude "$@"
+      fi
       local rc=$?
       reset-term
       return $rc

--- a/private_dot_claude/hooks/_common.sh
+++ b/private_dot_claude/hooks/_common.sh
@@ -21,10 +21,14 @@
 #                              age-based cleanup picks them up.
 
 # Initialize logging state. Defines:
-#   $LOGFILE — daily log under /tmp; appended to in addition to stdout
-#   $OUT     — /dev/tty when HOOK_DEBUG=1, else /dev/null (used to silence
-#              chatty subcommands while still capturing failures via log())
-#   log()    — prints "$timestamp $tag $msg" to stderr-via-tty and LOGFILE
+#   $LOGFILE    — daily log under /tmp; appended to in addition to stdout
+#   $TARGET_TTY — $CLAUDE_INVOKER_TTY if set (so detached agent-team
+#                 teammates can still reach the user's terminal), else
+#                 /dev/tty
+#   $OUT        — $TARGET_TTY when HOOK_DEBUG=1, else /dev/null (used to
+#                 silence chatty subcommands while still capturing failures
+#                 via log())
+#   log()       — prints "$timestamp $tag $msg" to $TARGET_TTY and LOGFILE
 # $1: tag string included in every log line (e.g. "[create]" / "[remove]")
 setup_logging() {
 	# Promoted to a global so log() can read it after setup_logging returns
@@ -32,8 +36,9 @@ setup_logging() {
 	LOG_TAG="$1"
 	LOGFILE="/tmp/worktree-hooks-$(date '+%Y-%m-%d').log"
 	rotate_log_if_oversized "$LOGFILE" "${HOOK_LOG_MAX_BYTES:-5242880}"
+	TARGET_TTY="${CLAUDE_INVOKER_TTY:-/dev/tty}"
 	if [ "${HOOK_DEBUG:-0}" = "1" ]; then
-		OUT=/dev/tty
+		OUT="$TARGET_TTY"
 	else
 		OUT=/dev/null
 	fi
@@ -41,7 +46,7 @@ setup_logging() {
 	# Defined here, called from caller scope after we return — invisible to
 	# static analysis, hence the disables for "unreachable" / "unused".
 	# shellcheck disable=SC2317,SC2329
-	log() { echo "$(date '+%Y-%m-%d %H:%M:%S') $LOG_TAG $*" | tee -a "$LOGFILE" >/dev/tty 2>/dev/null || true; }
+	log() { echo "$(date '+%Y-%m-%d %H:%M:%S') $LOG_TAG $*" | tee -a "$LOGFILE" >"$TARGET_TTY" 2>/dev/null || true; }
 	# Same shape, file-only — for verbose lines we don't want on screen.
 	# shellcheck disable=SC2317,SC2329
 	log_quiet() { echo "$(date '+%Y-%m-%d %H:%M:%S') $LOG_TAG $*" >> "$LOGFILE"; }

--- a/private_dot_claude/hooks/executable_worktree-create.sh
+++ b/private_dot_claude/hooks/executable_worktree-create.sh
@@ -223,9 +223,13 @@ find /tmp -maxdepth 1 -name 'worktree-hooks-*.log' -mtime +7 -delete 2>/dev/null
 # The trailing \e\\ is the OSC string terminator (ESC + backslash); the
 # literal `\\` is two chars in the single-quoted format and printf decodes
 # them to a single `\` — shellcheck SC1003 misreads it as quote-escaping.
+#
+# $TARGET_TTY (set by setup_logging) falls back to $CLAUDE_INVOKER_TTY
+# when /dev/tty is unreachable, e.g. when this hook runs under a detached
+# agent-team teammate that has no controlling terminal of its own.
 ABS_WORKTREE_DIR=$(cd "$WORKTREE_DIR" && pwd -P)
 # shellcheck disable=SC1003
-printf '\e]7;file://%s%s\e\\' "$HOSTNAME" "$ABS_WORKTREE_DIR" >/dev/tty 2>/dev/null || true
+printf '\e]7;file://%s%s\e\\' "$HOSTNAME" "$ABS_WORKTREE_DIR" >"$TARGET_TTY" 2>/dev/null || true
 
 # stdout = path only
 echo "$WORKTREE_DIR"


### PR DESCRIPTION
## Summary

Claude Code's experimental agent-teams feature spawns teammates as detached processes with no controlling tty of their own. They still inherit env vars from the launching shell (`GHOSTTY_SURFACE_ID`, `TERM`, …), but `/dev/tty` opens fail — so:

- the `WorktreeCreate` hook's OSC 7 emit (which tells Ghostty the worktree is the new cwd, so `cmd+t` / `cmd+d` open new panes there) silently no-ops, and
- `_common.sh`'s `log()` output also no-ops, leaving the daily log file missing every non-`log_quiet` line.

Repro: launch an agent-team teammate that calls `EnterWorktree`; `cmd+t` opens a new Ghostty pane in the wrapper shell's cwd (typically `~/repos`) instead of the new worktree.

## Fix

Capture the launching shell's tty in the `claude()` zsh wrapper and export it as `CLAUDE_INVOKER_TTY`. The hooks now resolve a `TARGET_TTY` that prefers `$CLAUDE_INVOKER_TTY` and falls back to `/dev/tty`, so:

- Foreground `claude` / `claude -w` keep working unchanged (they have a real `/dev/tty`; the fallback isn't hit).
- Detached agent-team teammates write OSC 7 + log output to the user's actual Ghostty pty via the inherited env var.

## Files

- `dot_zshrc` — `claude()` wrapper captures `$(tty)` and exports `CLAUDE_INVOKER_TTY` into the child env.
- `private_dot_claude/hooks/_common.sh` — `setup_logging` derives `$TARGET_TTY` from `$CLAUDE_INVOKER_TTY`; `log()` and `OUT` route through it.
- `private_dot_claude/hooks/executable_worktree-create.sh` — OSC 7 emit writes to `$TARGET_TTY`.

## Test plan

- [ ] `chezmoi apply` syncs the changes to `~/.zshrc` and `~/.claude/hooks/`.
- [ ] Start a new zsh in a Ghostty pane, confirm `env | grep CLAUDE_INVOKER_TTY` shows nothing (it's only set inside `claude()`).
- [ ] Run `claude -w foo`; in the foreground session, `cmd+t` lands in the worktree (regression check — should still work).
- [ ] From an agent-team teammate, call `EnterWorktree`; `cmd+t` in the launching Ghostty pane should now land in the new worktree.
- [ ] `/tmp/worktree-hooks-YYYY-MM-DD.log` should contain the full `→ Fetching origin…` / `✓ uv sync done` lines from teammate-triggered creates, not just the `payload:` line.