### PR TITLE
hooks: emit OSC 7 on SessionStart so Ghostty follows agents pre-worktree

### DIFF
--- a/private_dot_claude/hooks/executable_session-start-set-cwd.sh
+++ b/private_dot_claude/hooks/executable_session-start-set-cwd.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# ABOUTME: SessionStart hook — emit OSC 7 with the session's starting cwd
+# ABOUTME: so Ghostty opens new panes there before any worktree is created.
+
+set -euo pipefail
+
+# shellcheck source=_common.sh
+source "$(dirname "$0")/_common.sh"
+
+INPUT=$(cat)
+
+# Prefer the payload's cwd; fall back to CLAUDE_PROJECT_DIR. Either is fine —
+# we just need a real directory to announce to Ghostty.
+CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
+[ -n "$CWD" ] || CWD="${CLAUDE_PROJECT_DIR:-}"
+[ -n "$CWD" ] && [ -d "$CWD" ] || exit 0
+
+setup_logging "[session-start]"
+
+ABS_CWD=$(cd "$CWD" && pwd -P)
+
+# File-only — fires on every session start (including resumes/clears/compacts
+# and every agent-team teammate), so keep it out of the user's tty.
+log_quiet "--- SessionStart: $ABS_CWD ---"
+log_quiet "    payload: $(jq -c . <<< "$INPUT" 2>/dev/null || echo "$INPUT" | tr '\n' ' ')"
+
+# Tell Ghostty about the session's cwd so new panes open there even before
+# the worktree-create hook runs. $TARGET_TTY (set by setup_logging) prefers
+# $CLAUDE_INVOKER_TTY when set, so detached agent-team teammates still reach
+# the user's actual terminal — same pattern as worktree-create.sh.
+# shellcheck disable=SC1003
+printf '\e]7;file://%s%s\e\\' "$HOSTNAME" "$ABS_CWD" >"$TARGET_TTY" 2>/dev/null || true

--- a/private_dot_claude/settings.json
+++ b/private_dot_claude/settings.json
@@ -178,6 +178,16 @@
         ]
       }
     ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/session-start-set-cwd.sh"
+          }
+        ]
+      }
+    ],
     "SessionEnd": [
       {
         "hooks": [


### PR DESCRIPTION
## Summary
- Add a `SessionStart` hook (`session-start-set-cwd.sh`) that emits an OSC 7 `\e]7;file://host/path\e\\` for the session's starting `cwd`, routed through `$CLAUDE_INVOKER_TTY` (same pattern as worktree-create.sh)
- Closes the pre-worktree gap left by #26: before the first `WorktreeCreate` fires, Ghostty's tracked cwd for the user's pane was the parent shell's last `cd`, so new panes opened there instead of the agent's working dir. Now every session announces its cwd at startup; `WorktreeCreate` continues to update it later

## Test plan
- [x] `shellcheck -x` clean
- [x] Smoke-tested under `/bin/bash` (per repo CLAUDE.md, since chezmoi `run_*.sh` uses macOS bash 3.2): payload `{"cwd":"/tmp"}` writes the expected OSC 7 bytes to `$CLAUDE_INVOKER_TTY` and nothing to stdout
- [x] Verified bail-out when payload has no `cwd` and `CLAUDE_PROJECT_DIR` is unset
- [x] Verified fallback to `CLAUDE_PROJECT_DIR` when payload omits `cwd`
- [ ] After merge + `chezmoi apply`: spawn an agent-team teammate in a fresh repo (no worktree yet), confirm Cmd-D in the user's Ghostty pane opens at the teammate's cwd

🤖 Generated with [Claude Code](https://claude.com/claude-code)