### PR TITLE
zshrc: add agents alias

### DIFF
--- a/dot_zshrc
+++ b/dot_zshrc
@@ -367,6 +367,7 @@ alias ccc='claude'
 alias cccw='claude -w'
 alias cccy='claude --dangerously-skip-permissions'
 alias cccwy='claude --dangerously-skip-permissions -w'
+alias agents='cd ~/repos && claude agents'
 
 # GitHub
 alias ghw='gh repo view --web'


### PR DESCRIPTION
## Summary
- Adds `agents` alias that cds into `~/repos` then runs `claude agents`

## Test plan
- [x] `chezmoi apply` then open a new shell; `agents` jumps to `~/repos` and launches `claude agents`

🤖 Generated with [Claude Code](https://claude.com/claude-code)