### PR TITLE
zshrc: re-run brew shellenv so Homebrew git wins over Apple git

### DIFF
--- a/dot_zshrc
+++ b/dot_zshrc
@@ -65,6 +65,11 @@ ensure_dir_exists() {
 # Homebrew Setup                                          #
 ###########################################################
 if command_exists brew; then
+  # Re-run shellenv: /etc/zprofile's path_helper runs after .zshenv and
+  # pushes /opt/homebrew/bin behind /usr/bin, making Apple's git win over
+  # the Homebrew one (and breaking newer completions like `git chd<TAB>`).
+  eval "$(brew shellenv)"
+
   FPATH="${HOMEBREW_PREFIX}/share/zsh/site-functions:${FPATH}"
 
   export HOMEBREW_NO_ANALYTICS=1


### PR DESCRIPTION
## Summary

- macOS `/etc/zprofile` runs `path_helper` after `.zshenv`, prepending `/usr/bin` etc. and pushing `/opt/homebrew/bin` to the back of `PATH`.
- That made Apple's `git` 2.50.1 win over Homebrew's 2.54.0. Homebrew's newer zsh completion (`_git`) calls `git help --aliases-for-completion`, which Apple git doesn't recognize — so `git chd<TAB>` errored out with `unknown option`.
- Re-running `eval "$(brew shellenv)"` in `.zshrc` restores the intended PATH order for interactive shells. `typeset -U PATH` later in the file dedupes the entries the original `.zshenv` invocation left behind.

## Test plan

- [x] In a fresh interactive login zsh, `which git` returns `/opt/homebrew/bin/git` and `git --version` reports 2.54.0
- [x] `git chd<TAB><TAB>` completes without the `unknown option --aliases-for-completion` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)