### PR TITLE
hooks: add CwdChanged hook for OSC 7 follow into worktrees

### DIFF
--- a/private_dot_claude/hooks/executable_cwd-changed-osc7.sh
+++ b/private_dot_claude/hooks/executable_cwd-changed-osc7.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# ABOUTME: CwdChanged hook that emits OSC 7 so Ghostty's working-directory
+# ABOUTME: tracking follows the agent into worktrees and other cd moves.
+set -euo pipefail
+
+NEW_CWD=$(jq -r '.new_cwd // empty')
+[ -n "$NEW_CWD" ] || exit 0
+
+TTY="${CLAUDE_INVOKER_TTY:-/dev/tty}"
+HOST=$(hostname -s 2>/dev/null || echo localhost)
+
+printf '\033]7;file://%s%s\033\\' "$HOST" "$NEW_CWD" >"$TTY" 2>/dev/null || true

--- a/private_dot_claude/settings.json
+++ b/private_dot_claude/settings.json
@@ -158,6 +158,16 @@
   },
   "enableAllProjectMcpServers": true,
   "hooks": {
+    "CwdChanged": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/cwd-changed-osc7.sh"
+          }
+        ]
+      }
+    ],
     "WorktreeCreate": [
       {
         "hooks": [


### PR DESCRIPTION
## Summary
- Add `private_dot_claude/hooks/executable_cwd-changed-osc7.sh` that reads `new_cwd` from the hook payload and emits OSC 7 to `\$CLAUDE_INVOKER_TTY` (or `/dev/tty`).
- Wire it via a new `CwdChanged` entry in `settings.json`.

`CwdChanged` is a hook event present in the v2.1.140 binary's executor registry but absent from the public docs at code.claude.com. It fires every time the agent's working directory changes — including when Claude moves into `.claude/worktrees/<name>` before editing — which is exactly the moment SessionStart misses.

Background sessions hosted by the supervisor (`claude --bg`, agent view) still won't follow, because they have no tty pointing at the user's window. That gap needs an upstream `OnAttach` event or OSC 7 emission inside `claude attach`.

## Test plan
- [x] Hook script syntax-checks (`bash -n`)
- [x] Dry-run with fake payload writes a valid OSC 7 sequence (`ESC ] 7 ; file://host/path ESC \\`)
- [x] Empty `new_cwd` payload is a no-op (exit 0, no write)
- [ ] After `chezmoi apply`, open a Claude Code session in a repo, let it move into a worktree, and confirm Ghostty's window title / proxy icon reflect the worktree path