### PR TITLE
hooks: re-emit OSC 7 on SessionStart, UserPromptSubmit, and Stop

### DIFF
--- a/private_dot_claude/hooks/executable_cwd-changed-osc7.sh
+++ b/private_dot_claude/hooks/executable_cwd-changed-osc7.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
-# ABOUTME: CwdChanged hook that emits OSC 7 so Ghostty's working-directory
-# ABOUTME: tracking follows the agent into worktrees and other cd moves.
+# ABOUTME: Emits OSC 7 to the user's TTY so Ghostty's working-directory
+# ABOUTME: tracking follows the agent. Wired to CwdChanged and per-turn events.
 set -euo pipefail
 
 NEW_CWD=$(jq -r '.new_cwd // empty')
-[ -n "$NEW_CWD" ] || exit 0
+[ -n "$NEW_CWD" ] || NEW_CWD="$PWD"
 
 TTY="${CLAUDE_INVOKER_TTY:-/dev/tty}"
 HOST=$(hostname -s 2>/dev/null || echo localhost)

--- a/private_dot_claude/settings.json
+++ b/private_dot_claude/settings.json
@@ -158,6 +158,36 @@
   },
   "enableAllProjectMcpServers": true,
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/cwd-changed-osc7.sh"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/cwd-changed-osc7.sh"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/cwd-changed-osc7.sh"
+          }
+        ]
+      }
+    ],
     "CwdChanged": [
       {
         "hooks": [


### PR DESCRIPTION
## Summary
- Broaden the OSC 7 hook beyond `CwdChanged` so Ghostty's working-directory tracking stays fresh across session resumes, daemon-TTY rotation, and turn boundaries.
- Hook script falls back to `$PWD` when the event payload has no `.new_cwd`, so the same script serves all four events.
- Wired to `SessionStart`, `UserPromptSubmit`, `Stop`, and the existing `CwdChanged`.

## Test plan
- [x] Smoke-tested the script with and without `.new_cwd` in stdin; OSC 7 emitted correctly in both cases.
- [x] `jq -e '.hooks | keys'` confirms the settings.json hooks block parses.
- [ ] `chezmoi apply` then open a fresh `claude --resume` session and confirm the Ghostty pane title/cwd updates on the first prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)