### PR TITLE
hooks: drop rm -rf fallback in remove_worktree_branch

### DIFF
--- a/private_dot_claude/hooks/_common.sh
+++ b/private_dot_claude/hooks/_common.sh
@@ -199,8 +199,11 @@ branch_is_squash_merged_into() {
 # Best-effort removal of a worktree directory and its branch.
 #   1. Pre-delete heavy untracked dirs (.venv, node_modules) so `git worktree
 #      remove --force` doesn't trip over them.
-#   2. Run `git worktree remove --force`; on failure, fall back to rm -rf +
-#      `worktree prune` so we never leave a half-removed worktree.
+#   2. Run `git worktree remove --force`; on failure, prune git's bookkeeping
+#      and warn — but leave the directory alone. Matches Claude Code 2.1.147's
+#      built-in cleanup behavior, which dropped the rm -rf fallback to avoid
+#      destroying gitignored or in-progress files when remove fails for an
+#      unexpected reason.
 #   3. Delete the local branch if it still exists.
 #   4. Clear core.worktree if it pointed at the removed dir (an old git bug
 #      could leave that pointer dangling).
@@ -215,7 +218,7 @@ remove_worktree_branch() {
 	fi
 	rm -rf "$wt_dir/.venv" "$wt_dir/node_modules"
 	git -C "$repo" worktree remove --force "$wt_dir" >"$OUT" 2>&1 || {
-		rm -rf "$wt_dir"
+		log "⚠ git worktree remove --force failed for $wt_dir; leaving directory in place"
 		git -C "$repo" worktree prune >"$OUT" 2>&1 || true
 	}
 	if git -C "$repo" show-ref --verify --quiet "refs/heads/$branch" 2>/dev/null; then


### PR DESCRIPTION
## Summary
- When `git worktree remove --force` failed, `_common.sh:remove_worktree_branch` used to `rm -rf "$wt_dir"` as a fallback. That could silently destroy gitignored or in-progress files in the worktree on the rare failure path (corrupt `.git` pointer, locked file, weird permissions).
- Aligns with Claude Code 2.1.147's built-in: on failure, leave the directory alone, log a warning, and still `worktree prune` git's bookkeeping (no-op when the dir survives, useful if the dir was already gone).
- Same happy-path behavior. No change to the pre-delete of `.venv` / `node_modules`.

## Test plan
- [x] Failure path (worktree `.git` pointer corrupted so `git worktree remove --force` errors): dir + user files preserved, warning logged, branch left alone (still checked out)
- [x] Happy path (normal removal): dir + branch removed, no warning, no behavioral change

🤖 Generated with [Claude Code](https://claude.com/claude-code)