### PR TITLE
hooks: don't classify never-pushed worktrees as merged

### DIFF
--- a/private_dot_claude/hooks/_common.sh
+++ b/private_dot_claude/hooks/_common.sh
@@ -295,7 +295,7 @@ clean_stale_worktrees() {
 	[ -d "$dir" ] || return 0
 	git -C "$repo" fetch origin --prune >"$OUT" 2>&1 || true
 
-	local stale_dir stale_name stale_branch has_upstream should_clean reason
+	local stale_dir stale_name stale_branch upstream has_upstream should_clean reason
 	local merged_pr wt_created age_hours unique_commits
 	local removed=0 kept=0 scanned=0
 	for stale_dir in "$dir"/*/; do
@@ -305,7 +305,19 @@ clean_stale_worktrees() {
 		[ "$stale_name" = "$skip" ] && continue
 		scanned=$((scanned + 1))
 
-		has_upstream=$(git -C "$repo" for-each-ref --format='%(upstream)' "refs/heads/$stale_branch" 2>/dev/null)
+		# A branch made with `git worktree add -b <name> origin/<default>`
+		# inherits origin/<default> as its upstream via branch.autoSetupMerge
+		# (on by default). That is NOT evidence the branch was ever pushed —
+		# so only count an upstream that points at the branch's own remote ref.
+		# Otherwise a fresh, never-pushed worktree takes the "pushed then remote
+		# gone" path, looks squash-merged (no unique commits vs base), and gets
+		# deleted mid-run.
+		upstream=$(git -C "$repo" for-each-ref --format='%(upstream)' "refs/heads/$stale_branch" 2>/dev/null)
+		if [ "$upstream" = "refs/remotes/origin/$stale_branch" ]; then
+			has_upstream="$upstream"
+		else
+			has_upstream=""
+		fi
 		should_clean=false
 		reason=""
 


### PR DESCRIPTION
## The bug

`clean_stale_worktrees` ran on every WorktreeCreate/WorktreeRemove and deleted brand-new worktrees mid-run — most visibly background-agent worktrees, which lack the live-session shield.

Root cause chain:
1. `git worktree add -b worktree-<name> origin/<default>` makes the new branch **inherit `origin/<default>` as its upstream** via `branch.autoSetupMerge` (on by default). Verified live: a fresh branch off `origin/main` comes out tracking `origin/main`.
2. So `has_upstream` was always non-empty → cleanup took the "pushed at some point" path.
3. The branch's own remote ref (`refs/remotes/origin/worktree-<name>`) never exists → "remote branch gone", and `git cherry origin/main <branch>` shows no unique commits for an uncommitted worktree → looks squash-merged → **deleted**.

The only thing shielding a fresh worktree was `worktree_has_active_session`, which only finds interactive sessions (whose cwd is registered under `~/.claude/sessions`). Background subagent worktrees aren't registered → unshielded → removed mid-run. There's also a latent race for interactive worktrees.

## The fix

Count an upstream as "pushed" only when it points at the branch's **own** remote ref, not `origin/<default>` inherited via autoSetupMerge. Fresh worktrees then route to the never-pushed path, where the age check preserves them (a 0-hour-old worktree is never cleaned). Pushed-then-merged worktrees still clean correctly.

## Verification

Isolated temp-repo harness, dry-run cleanup over three worktrees:
- **fresh** (never pushed, off `origin/main`) → **kept** ← the bug
- **merged** (pushed `-u`, remote branch gone) → **cleaned** ✓
- **active** (pushed `-u`, remote present, unique commits) → **kept** ✓

`bash -n` (3.2) clean, shellcheck clean.

## Noted behavior change

A worktree pushed **without** `-u` (so upstream stays `origin/main`) that later gets squash-merged now routes to the never-pushed path instead of being cleaned. `gh pr create` pushes with `-u`, so the workflow's normal path is unaffected, and the conservative direction (keep, don't delete) matches the function's "never silently throw away in-progress local work" intent.

## Optional follow-ups (not in this PR)

- (a) In `branch_created_at`, treat an unknown/0 timestamp as "don't clean" rather than "infinitely old".
- (b) Skip cleaning any worktree younger than ~10 min as a blanket race guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)