### PR TITLE
hooks: treat unknown worktree creation time as too-young-to-clean

### DIFF
--- a/private_dot_claude/hooks/_common.sh
+++ b/private_dot_claude/hooks/_common.sh
@@ -346,10 +346,15 @@ clean_stale_worktrees() {
 			fi
 		else
 			# Never pushed. Only clean if it's old AND has no unique commits,
-			# so we never silently throw away in-progress local work.
+			# so we never silently throw away in-progress local work. A 0
+			# timestamp means the creation time is unknown (no reflog); treat
+			# that as too-young-to-clean rather than infinitely old, so missing
+			# data never lets us delete a worktree.
 			wt_created=$(branch_created_at "$repo" "$stale_branch")
 			age_hours=$(( ($(date +%s) - wt_created) / 3600 ))
-			if [ "$age_hours" -ge 24 ]; then
+			if [ "$wt_created" -le 0 ]; then
+				log "⏭ Keeping stale worktree: $stale_name (unknown creation time)"
+			elif [ "$age_hours" -ge 24 ]; then
 				unique_commits=$(unique_commits_against "$repo" "$base_ref" "$stale_branch")
 				if [ "$unique_commits" -eq 0 ]; then
 					should_clean=true


### PR DESCRIPTION
Optional hardening follow-up to #38 (which fixed the autoSetupMerge misread that caused fresh worktrees to be deleted).

## Why

The core fix routes fresh, never-pushed worktrees to the "never pushed" path, where they're kept if younger than 24h. That path computes age from `branch_created_at`, which returns `0` when the branch has no reflog. Fed into the age math, `0` becomes ~490,000h → "infinitely old" → with no unique commits, `should_clean=true`. So a missing creation timestamp is currently the one input that still lets cleanup delete a worktree.

## Change

Guard the never-pushed cleanup on a known (`> 0`) timestamp. Unknown creation time is now treated as too-young-to-clean and logged as `⏭ Keeping stale worktree: <name> (unknown creation time)`.

## Verification

Temp-repo harness: a `worktree-*` branch with its reflog removed (so `branch_created_at` → `0`) is now **kept** instead of deleted. `bash -n` (3.2) and shellcheck both clean.

## On the second hardening bullet from #37

The "skip anything younger than ~10 min" race guard is deliberately **not** included. #38 already routes fresh worktrees to the safe never-pushed path (kept under 24h), so the race that bullet targeted is closed; a blanket 10-min floor would only add a redundant rule that also delays legitimate cleanup of short-lived merged worktrees. Can revisit if a real race is observed.

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)