### PR TITLE
add digs shortcut to launch a background dig exploration

### DIFF
--- a/dot_zshrc
+++ b/dot_zshrc
@@ -374,6 +374,12 @@ alias cccy='claude --dangerously-skip-permissions'
 alias cccwy='claude --dangerously-skip-permissions -w'
 alias agents='cd ~/repos && claude agents'
 
+# Launch a background dig exploration in the digs workbench; topic inline
+digs() {
+    ( cd ~/repos/digs 2>/dev/null || { echo "digs: ~/repos/digs not found" >&2; exit 1; }
+      claude --bg "$*" )
+}
+
 # GitHub
 alias ghw='gh repo view --web'
 alias ghp='gh pr list --web'


### PR DESCRIPTION
Closes #40.

Adds a `digs()` shell function to `dot_zshrc` that dispatches a background dig exploration in `~/repos/digs` with the topic inline:

```sh
digs why does lavanguardia throw ERR_SSL_UNRECOGNIZED_NAME_ALERT
```

### Decisions
- **Function, not alias** — the documented usage is unquoted multi-word; only `"$*"` joins it into the single prompt arg `claude` expects. An alias would split it into separate argv. The subshell also keeps `cd` from leaking into the caller's shell.
- **Literal path + loud guard** — a missing `~/repos/digs` fails with a message instead of silently dispatching in the wrong cwd. Matches the existing `cdm()` guard idiom in the file.
- **No `--name` / no `--permission-mode`** — verified against the live setup: sessions already auto-name descriptively, and the global `defaultMode: "auto"` is inherited in the digs dir. Both flags would only regress behavior.

### Verification
- `zsh -n` parse OK
- missing-dir case aborts loudly without invoking `claude`
- present-dir case runs `claude --bg` in `~/repos/digs` with the topic intact and leaves the caller's cwd unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)