### PR TITLE
commands: add /ship and /land for one-shot merge flows

### DIFF
--- a/dot_agents/AGENTS.md
+++ b/dot_agents/AGENTS.md
@@ -120,7 +120,7 @@ When asked to do something, just do it - including obvious follow-up actions nee
 - NEVER use `git add -A` unless you've just done a `git status` - Don't add random test files to the repo.
 - Before opening a PR (`gh pr create`), fetch `origin` and rebase your worktree branch onto the fresh default-branch tip. Keeps the diff honest and CI relevant. Do NOT rebase a branch after it has been pushed and reviewed without David's say-so.
 - When merging PRs from a worktree, NEVER use `--delete-branch`. It fails because `gh` tries to checkout the default branch locally, which is already checked out in the main worktree. Just use `gh pr merge --squash`. Remote branch cleanup is handled by GitHub's auto-delete setting, and local worktree cleanup is handled by the worktree-create hook.
-- After a PR merges successfully, bring the main working checkout up to date without being asked: switch it to the default branch and fast-forward to the merged tip (`git -C <main checkout> switch main && git -C <main checkout> pull`). Don't make me ask for this every time.
+- After a PR merges successfully, "go back to main" means two things, both without being asked: (1) bring the main working checkout up to date — switch it to the default branch and fast-forward to the merged tip; and (2) move the session out of the now-dead worktree back to the main checkout (e.g. `ExitWorktree` with `remove` — squash-merge makes the branch look unmerged, so confirm the tree is clean and the change is on `origin/main`, then discard). Don't leave the session parked in a merged worktree, and don't make me ask for this every time.
 
 ## Testing
 

--- a/private_dot_claude/commands/land.md
+++ b/private_dot_claude/commands/land.md
@@ -1,0 +1,28 @@
+---
+allowed-tools: Bash(git status:*), Bash(git diff:*), Bash(git branch:*), Bash(git switch:*), Bash(git add:*), Bash(git commit:*), Bash(git push:*), Bash(git merge:*), Bash(git log:*), Bash(git worktree:*), Bash(grep:*), ExitWorktree
+description: Commit and fast-forward the change straight onto main, no PR, then clean up the worktree
+---
+
+## Context
+
+- This repo is PUBLIC: never commit secrets (`sk-`, `ghp_`, `gho_`, `AKIA`, `Bearer`, passwords, private hostnames/IPs, SSH keys, `.env` contents).
+- Git status: !`git status`
+- Diff (staged + unstaged): !`git diff HEAD`
+- Current branch: !`git branch --show-current`
+- Worktrees: !`git worktree list`
+
+## Your task
+
+Land these changes directly on the default branch without opening a PR. Use this only for trivial solo changes that don't need review — reach for `/ship` when you want the PR trail or a second pair of eyes.
+
+1. Scan the diff for secrets (see the patterns above). If anything matches, STOP and report it instead of committing.
+2. Create ONE commit on the current branch with a lowercase, imperative, concise subject. End the message with the trailer:
+   `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`
+3. Identify the main working tree (first entry of `git worktree list`) and its default branch.
+4. Fast-forward the default branch onto this commit and push, operating on the main checkout so you don't disturb the session's cwd yet:
+   - `git -C <main> switch <default>`
+   - `git -C <main> merge --ff-only <this-branch>`
+   - `git -C <main> push origin <default>`
+   - If the fast-forward is rejected because the default branch moved, STOP and tell David — rebase is his call, don't force it.
+5. Return the session to the main checkout and remove this worktree: if this session created it (via EnterWorktree), call `ExitWorktree` with action `remove` (the commit is now the default-branch tip, so it removes cleanly). Otherwise switch to the main working tree and delete the merged branch yourself.
+6. Report the new default-branch tip.

--- a/private_dot_claude/commands/ship.md
+++ b/private_dot_claude/commands/ship.md
@@ -1,0 +1,29 @@
+---
+allowed-tools: Bash(git status:*), Bash(git diff:*), Bash(git branch:*), Bash(git switch:*), Bash(git add:*), Bash(git commit:*), Bash(git push:*), Bash(git pull:*), Bash(git fetch:*), Bash(git log:*), Bash(git worktree:*), Bash(gh pr create:*), Bash(gh pr merge:*), Bash(gh pr view:*), Bash(grep:*), ExitWorktree
+description: Commit, push, open a PR, squash-merge it, then return to an updated main checkout
+---
+
+## Context
+
+- This repo is PUBLIC: never commit secrets (`sk-`, `ghp_`, `gho_`, `AKIA`, `Bearer`, passwords, private hostnames/IPs, SSH keys, `.env` contents).
+- Git status: !`git status`
+- Diff (staged + unstaged): !`git diff HEAD`
+- Current branch: !`git branch --show-current`
+- Worktrees: !`git worktree list`
+
+## Your task
+
+Take the changes above all the way to a merged, cleaned-up state. Do not stop partway.
+
+1. Scan the diff for secrets (see the patterns above). If anything matches, STOP and report it instead of committing.
+2. If on the default branch, create a feature branch first. Otherwise use the current branch.
+3. Create ONE commit with a lowercase, imperative, concise subject. End the message with the trailer:
+   `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`
+4. Push the branch: `git push -u origin <branch>`.
+5. Open a PR with `gh pr create` — title from the commit subject, body summarizing the change.
+6. Squash-merge it: `gh pr merge --squash`. NEVER pass `--delete-branch` from a worktree (it fails trying to checkout the default branch that the main worktree already holds).
+7. Return the session to the main checkout and bring it up to date:
+   - If this session created the current worktree (via EnterWorktree), call `ExitWorktree` with action `remove`. Squash-merge leaves the local branch looking unmerged by ancestry, so after confirming the working tree is clean and the change is on `origin/<default>`, pass `discard_changes: true`.
+   - Otherwise, switch the session to the main working tree (first entry of `git worktree list`) yourself.
+   - In the main checkout: `git switch <default> && git pull --ff-only`.
+8. Report the PR number/URL and confirm the main checkout is at the merged tip.


### PR DESCRIPTION
Adds two prompt-style slash commands under `private_dot_claude/commands/` (chezmoi deploys them to `~/.claude/commands/`), so the four-step "commit, push, PR, merge" ask becomes one word.

- **`/ship`** — full PR flow: secret-scan → commit → push → open PR → squash-merge → ExitWorktree back to the main checkout → fast-forward main.
- **`/land`** — lightweight, no PR: secret-scan → commit → fast-forward the change straight onto the default branch → clean up the worktree. For trivial solo changes.

Both bake in the gotchas: public-repo secret scan, the `Co-Authored-By` trailer, never `--delete-branch` from a worktree, and the squash-merge false-positive when removing the worktree.

Also updates the AGENTS.md post-merge rule so "go back to main" explicitly covers both halves: refresh the branch AND exit the dead worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)