### PR TITLE
packages: add anthropics/tap/ant cli

### DIFF
--- a/run_onchange_darwin-install-packages.sh.tmpl
+++ b/run_onchange_darwin-install-packages.sh.tmpl
@@ -85,6 +85,7 @@ brew "tig"                  # git TUI
 # AI / inference tooling
 #
 brew "agent-browser"        # headless browser driver for agents
+brew "anthropics/tap/ant"   # Anthropic 'ant' CLI
 brew "gemini-cli"           # Google Gemini CLI
 cask "codex"                # OpenAI Codex CLI (rust binary)
 cask "copilot-cli"          # GitHub Copilot CLI


### PR DESCRIPTION
Adds `brew "anthropics/tap/ant"` to the AI / inference tooling section of the macOS brew bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)