### PR TITLE
packages: install ant as cask, not formula

### DIFF
--- a/run_onchange_darwin-install-packages.sh.tmpl
+++ b/run_onchange_darwin-install-packages.sh.tmpl
@@ -85,8 +85,8 @@ brew "tig"                  # git TUI
 # AI / inference tooling
 #
 brew "agent-browser"        # headless browser driver for agents
-brew "anthropics/tap/ant"   # Anthropic 'ant' CLI
 brew "gemini-cli"           # Google Gemini CLI
+cask "anthropics/tap/ant"   # 'ant' — CLI for the Claude Platform
 cask "codex"                # OpenAI Codex CLI (rust binary)
 cask "copilot-cli"          # GitHub Copilot CLI
 cask "macwhisper"           # local Whisper transcription app


### PR DESCRIPTION
`anthropics/tap/ant` is a cask ("CLI for the Claude Platform"), not a formula, so `brew "..."` failed with "No available formula". Switches it to `cask "..."` and moves it into the cask cluster.

Follow-up fix to #47.

🤖 Generated with [Claude Code](https://claude.com/claude-code)