### PR TITLE
skills: make the wishlist the single source of truth

### DIFF
--- a/dot_agents/skills.wishlist
+++ b/dot_agents/skills.wishlist
@@ -1,4 +1,5 @@
 alltuner/skills --skill vacant
 anthropics/skills --skill frontend-design
-pbakaus/impeccable --skill impeccable
+microsoft/azure-skills --skill microsoft-foundry
+pbakaus/impeccable --skill impeccable --skill layout --skill shape
 stripe/ai --skill stripe-best-practices --skill stripe-projects --skill upgrade-stripe

--- a/dot_local/bin/executable_skills-bootstrap
+++ b/dot_local/bin/executable_skills-bootstrap
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# ABOUTME: Install every agent skill listed in ~/.agents/skills.wishlist into all agents.
+# ABOUTME: Idempotent — bunx refreshes existing skills, so it is safe to re-run.
+set -euo pipefail
+
+wishlist="${HOME}/.agents/skills.wishlist"
+
+if ! command -v bunx >/dev/null 2>&1; then
+  echo "skills-bootstrap: bunx not found; skipping" >&2
+  exit 0
+fi
+
+if [ ! -f "${wishlist}" ]; then
+  echo "skills-bootstrap: no wishlist at ${wishlist}" >&2
+  exit 0
+fi
+
+while IFS= read -r line; do
+  case "${line}" in
+    ''|\#*) continue ;;
+  esac
+  # Word-split the entry ("owner/repo --skill a --skill b") into bunx arguments.
+  # shellcheck disable=SC2086
+  bunx skills add ${line} \
+    --agent claude-code \
+    --agent codex \
+    --agent gemini-cli \
+    --agent github-copilot \
+    --agent opencode \
+    -g -y
+done < "${wishlist}"

--- a/dot_zshrc
+++ b/dot_zshrc
@@ -398,39 +398,23 @@ alias dcl='docker compose logs -f --tail 100'
 dlogs() { docker logs -f --tail 100 "$1"; }   # Follow container logs
 dexec() { docker exec -it "$1" /bin/sh; }    # Shell into a container
 
-# Add a global agent skill and wire it into every agent we use.
+# Add an agent skill to the wishlist, then install it into every agent we use.
+# Records intent in the chezmoi-managed wishlist source and applies it, so the
+# wishlist stays the single source of truth (commit it afterwards). The install
+# itself runs via `skills-bootstrap` (~/.local/bin), shared with the chezmoi hook.
 # Usage: skills-add <source> [--skill <name> ...]
-if command_exists bunx; then
+if command_exists chezmoi; then
   skills-add() {
-      bunx skills add "$@" \
-          --agent claude-code \
-          --agent codex \
-          --agent gemini-cli \
-          --agent github-copilot \
-          --agent opencode \
-          -g -y || return
-
-      local wishlist="$HOME/.agents/skills.wishlist"
-      local entry="$*"
-      if [[ ! -f "$wishlist" ]] || ! grep -qFx -- "$entry" "$wishlist"; then
-          echo "$entry" >> "$wishlist"
-          echo "[skills-add] appended to $wishlist"
-          echo "[skills-add] run: chezmoi re-add $wishlist && cd \$(chezmoi source-path) && git status"
+      local src entry
+      src="$(chezmoi source-path "$HOME/.agents/skills.wishlist")" || return
+      entry="$*"
+      if grep -qFx -- "$entry" "$src"; then
+          echo "[skills-add] already in wishlist: $entry"
+      else
+          echo "$entry" >> "$src"
+          echo "[skills-add] added to wishlist: $entry (commit it in \$(chezmoi cd))"
       fi
-  }
-
-  # Install the curated set of agent skills from ~/.agents/skills.wishlist
-  # (chezmoi-managed). Idempotent — safe to re-run, bunx refreshes existing.
-  skills-bootstrap() {
-      local wishlist="$HOME/.agents/skills.wishlist"
-      if [[ ! -f "$wishlist" ]]; then
-          echo "skills-bootstrap: no wishlist at $wishlist" >&2
-          return 1
-      fi
-      while IFS= read -r line; do
-          [[ -z "$line" || "$line" == \#* ]] && continue
-          skills-add ${=line}
-      done < "$wishlist"
+      chezmoi apply "$HOME/.agents/skills.wishlist" && skills-bootstrap
   }
 fi
 

--- a/run_onchange_after_install-skills.sh.tmpl
+++ b/run_onchange_after_install-skills.sh.tmpl
@@ -1,0 +1,14 @@
+{{- if eq .chezmoi.os "darwin" -}}
+#!/bin/bash
+# ABOUTME: Install agent skills whenever the wishlist changes (and on a fresh machine).
+# ABOUTME: chezmoi re-runs this script when the wishlist hash below changes.
+set -euo pipefail
+
+# skills.wishlist hash: {{ include "dot_agents/skills.wishlist" | sha256sum }}
+
+if command -v bunx >/dev/null 2>&1 && [ -x "${HOME}/.local/bin/skills-bootstrap" ]; then
+  "${HOME}/.local/bin/skills-bootstrap"
+else
+  echo "skills: bunx or skills-bootstrap not ready yet; will install on next 'chezmoi apply'" >&2
+fi
+{{ end -}}


### PR DESCRIPTION
Cleans up the agent-skills glue after evaluating (and rejecting) Homecrew/crew as a replacement for the skills.sh setup.

## What changes
- **`skills-add` writes to the chezmoi *source*** wishlist and `chezmoi apply`s it — no more manual `chezmoi re-add` + commit dance. The wishlist is now the single source of truth.
- **Install loop extracted to `~/.local/bin/skills-bootstrap`** (one home for the logic), shared by the shell and the new hook. The old zsh `skills-bootstrap` function is removed.
- **New `run_onchange_after_install-skills.sh.tmpl`** reinstalls skills whenever the wishlist changes and on a fresh machine (guarded on `bunx` presence; runs in the after-phase so the bootstrap script and bun are already deployed).
- **Wishlist reconciled** with reality: declares `layout`, `shape` (from `pbakaus/impeccable`) and `microsoft-foundry` (from `microsoft/azure-skills`), which were installed but undeclared.

## Testing
- `bash -n` (macOS `/bin/bash` 3.2) clean on the script and the rendered hook.
- Hook renders via `chezmoi execute-template`; embedded hash tracks the wishlist content.
- Word-split/skip logic verified with a stubbed `bunx` (comments + blanks skipped, multi-`--skill` entries expand correctly).
- `chezmoi apply --dry-run` recognizes the wishlist diff, the deployed script (mode 100755), and the `install-skills.sh` hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)