### PR TITLE
packages: use owned iwork mas ids

### DIFF
--- a/run_onchange_darwin-install-packages.sh.tmpl
+++ b/run_onchange_darwin-install-packages.sh.tmpl
@@ -111,9 +111,9 @@ cask "raycast"                          # launcher / Spotlight replacement
 #
 mas "DaisyDisk",          id: 411643860
 mas "Obsidian Web Clipper", id: 6720708363
-mas "Keynote",            id: 409183694
-mas "Numbers",            id: 409203825
-mas "Pages",              id: 409201541
+mas "Keynote",            id: 361285480
+mas "Numbers",            id: 361304891
+mas "Pages",              id: 361309726
 mas "Slack",              id: 803453959
 mas "Xcode",              id: 497799835
 


### PR DESCRIPTION
`mas` failed to install Keynote/Numbers/Pages with "No apps found in the App Store for ADAM ID". The `409xxx` IDs in the Brewfile are the iWork '11 listings, which aren't in the account's purchase history. The account owns the older `361xxx` listings (confirmed via `mas list`).

- Keynote: 409183694 → 361285480
- Numbers: 409203825 → 361304891
- Pages:   409201541 → 361309726

The comment "IDs are stable across machines" still holds — these are per-Apple-ID purchase IDs, stable for this account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)