### PR TITLE
packages: drop deprecated docker-completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,8 +201,7 @@ Mise tools auto-upgrade daily in the background via `.zshrc`.
 | Package | Description |
 |---|---|
 | gcloud-cli | Google Cloud SDK (cask) |
-| docker-desktop | Docker (cask) |
-| docker-completion | Docker shell completions |
+| docker-desktop | Docker Desktop (cask) — ships the docker CLI and shell completions |
 
 #### Fonts
 

--- a/run_onchange_darwin-install-packages.sh.tmpl
+++ b/run_onchange_darwin-install-packages.sh.tmpl
@@ -94,8 +94,7 @@ cask "macwhisper"           # local Whisper transcription app
 #
 # Docker
 #
-cask "docker-desktop"
-brew "docker-completion"
+cask "docker-desktop"        # ships the docker CLI + zsh completions (~/.docker/completions, wired in .zshrc)
 
 #
 # Productivity / end-user apps (casks)


### PR DESCRIPTION
`docker-completion` is deprecated upstream (Homebrew disables it 2027-05-31). It was redundant: Docker Desktop already ships the docker CLI and writes the dynamic zsh completion to `~/.docker/completions/_docker`, which `.zshrc` already adds to `fpath`.

- Removed `brew "docker-completion"` from the install template (kept `docker-desktop`, annotated why no separate completion package).
- Removed the README row; noted Desktop ships the CLI + completions.
- Uninstalled the package locally and verified a fresh login zsh still autoloads `_docker` from the native dir.

Did **not** switch to the `docker` formula: it installs `/opt/homebrew/bin/docker`, which shadows Desktop's `/usr/local/bin/docker` in PATH — only sensible when not running Docker Desktop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)