### PR TITLE
zsh: drop ngrok, cache fzf/atuin/zoxide/uv/uvx shell-init

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,6 @@ Mise tools auto-upgrade daily in the background via `.zshrc`.
 | knock | Port-knock client |
 | lazydocker | Docker TUI |
 | litecli | SQLite CLI with autocomplete |
-| ngrok | Secure tunnels to localhost (cask) |
 | qrencode | QR code generator |
 | rsync | File sync |
 | sc-im | Terminal spreadsheet editor |

--- a/dot_zshrc
+++ b/dot_zshrc
@@ -49,10 +49,17 @@ command_exists() {
   command -v "$1" &>/dev/null
 }
 
-load_if_exists() {
-  if command_exists "$1"; then
-    eval "$2"
-  fi
+# Cache a tool's shell-init output and source it, regenerating only when the
+# binary is newer than the cache. Turns a per-shell subprocess spawn into a
+# file source. Same pattern as the mise/starship caches below.
+# Usage: cache_eval <cache-name> <binary> <init args...>
+cache_eval() {
+  local name=$1 bin=$2; shift 2
+  local src; src=$(command -v "$bin" 2>/dev/null) || return
+  ensure_dir_exists "${XDG_CACHE_HOME}/zsh"
+  local cache="${XDG_CACHE_HOME}/zsh/${name}-init.zsh"
+  [[ ! -s "$cache" || "$src" -nt "$cache" ]] && "$bin" "$@" > "$cache"
+  source "$cache"
 }
 
 ensure_dir_exists() {
@@ -225,13 +232,13 @@ else
 fi
 
 if (( $+functions[zsh-defer] )); then
-  zsh-defer -c 'eval "$(fzf --zsh)"'
-  zsh-defer -c 'eval "$(atuin init zsh --disable-up-arrow)"'
-  zsh-defer -c 'eval "$(zoxide init zsh)"'
+  zsh-defer -c 'cache_eval fzf fzf --zsh'
+  zsh-defer -c 'cache_eval atuin atuin init zsh --disable-up-arrow'
+  zsh-defer -c 'cache_eval zoxide zoxide init zsh'
 else
-  load_if_exists fzf 'eval "$(fzf --zsh)"'
-  load_if_exists atuin 'eval "$(atuin init zsh --disable-up-arrow)"'
-  load_if_exists zoxide 'eval "$(zoxide init zsh)"'
+  cache_eval fzf fzf --zsh
+  cache_eval atuin atuin init zsh --disable-up-arrow
+  cache_eval zoxide zoxide init zsh
 fi
 
 # Print directory after zoxide jumps
@@ -461,19 +468,12 @@ zstyle ':completion:*' menu select
 setopt GLOB_DOTS
 
 # Tool-specific completions (deferred when available)
-# ngrok: only load if it outputs zsh completions (snap version outputs bash only)
 if (( $+functions[zsh-defer] )); then
-  zsh-defer -c 'command_exists ngrok && ngrok completion 2>/dev/null | head -1 | grep -q compdef && eval "$(ngrok completion)"'
-elif command_exists ngrok && ngrok completion 2>/dev/null | head -1 | grep -q compdef; then
-  eval "$(ngrok completion)"
-fi
-
-if (( $+functions[zsh-defer] )); then
-  zsh-defer -c 'eval "$(uvx --generate-shell-completion zsh)"'
-  zsh-defer -c 'eval "$(uv generate-shell-completion zsh)"'
+  zsh-defer -c 'cache_eval uvx uvx --generate-shell-completion zsh'
+  zsh-defer -c 'cache_eval uv uv generate-shell-completion zsh'
 else
-  command_exists uvx && eval "$(uvx --generate-shell-completion zsh)"
-  command_exists uv && eval "$(uv generate-shell-completion zsh)"
+  cache_eval uvx uvx --generate-shell-completion zsh
+  cache_eval uv uv generate-shell-completion zsh
 fi
 
 # Google Cloud SDK completions

--- a/run_onchange_darwin-install-packages.sh.tmpl
+++ b/run_onchange_darwin-install-packages.sh.tmpl
@@ -48,7 +48,6 @@ brew "watchman"             # Facebook file-watcher (RN / Xcode tooling)
 brew "wget"
 brew "yq"                   # YAML/XML/TOML jq-alike
 brew "yt-dlp"               # video downloader (youtube-dl fork)
-cask "ngrok"                # local-to-public tunnels
 
 #
 # Modern replacements for classic unix tools


### PR DESCRIPTION
## Why

Diagnosed a "first keystrokes after opening a terminal buffer for ~1s, then it's fast" issue. Root cause: the instant prompt is bought by deferring all tool inits past the first prompt with `zsh-defer`, but each deferred task forks a subprocess for command substitution (`eval "$(tool init)"`). `zsh-defer` yields to the keyboard *between* tasks, not *during* a fork, so keystrokes typed into that window buffer until the batch drains.

## Changes

- **Remove ngrok** entirely (unused). Its completion probe spawned `ngrok` **twice on every shell** just to test whether it emits zsh output — the single most expensive deferred item. Dropped from `dot_zshrc`, the Brewfile cask, and the README.
- **Cache the remaining inits** (`fzf`, `atuin`, `zoxide`, `uv`, `uvx`) via a new `cache_eval` helper that writes the init output to `~/.cache/zsh/<tool>-init.zsh` and regenerates only when the binary is newer — the same pattern already used for `mise` and `starship`. Sourcing a file replaces the per-shell fork, so the deferred batch stops blocking input.
- Removed the now-dead `load_if_exists` helper (only used by the replaced branches).

These tools reference themselves by name in their init output (unlike starship, which bakes an absolute path), so the cache stays valid across mise upgrades and needs no heal hook.

## Verification

- `zsh -n dot_zshrc` parses cleanly
- `cache_eval` tested: creates caches, sources them, no-ops on a missing binary, and skips regeneration when the cache is fresh
- uv/uvx caches source without `compdef` errors when compinit has run first (matching real `.zshrc` ordering)
- zero `ngrok` references remain in tracked content

**Still needs the real-terminal smoke test** (`chezmoi apply` + open a new terminal) to confirm the typing lag is gone — that's the one thing automation can't do here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)