### PR TITLE
zsh: lazy-autoload uv/uvx completions instead of sourcing them

### DIFF
--- a/dot_zshrc
+++ b/dot_zshrc
@@ -62,6 +62,23 @@ cache_eval() {
   source "$cache"
 }
 
+# Install a command's zsh completion as an autoloaded fpath function so its
+# (often large) body loads lazily on first completion instead of being sourced
+# into every shell. Regenerate when the binary changes, dropping the compdump
+# so the next compinit re-registers it. Must run before compinit.
+# Usage: ensure_completion <cmd> <binary> <generate args...>
+ensure_completion() {
+  local name=$1 bin=$2; shift 2
+  local src; src=$(command -v "$bin" 2>/dev/null) || return
+  local dir="${XDG_DATA_HOME}/zsh/completions"
+  ensure_dir_exists "$dir"
+  local comp="$dir/_$name"
+  if [[ ! -s "$comp" || "$src" -nt "$comp" ]]; then
+    "$bin" "$@" > "$comp"
+    rm -f "${XDG_CACHE_HOME}/zsh/zcompdump"
+  fi
+}
+
 ensure_dir_exists() {
   if [[ ! -d "$1" ]]; then
     mkdir -p "$1"
@@ -441,6 +458,13 @@ if [[ -d "$HOME/.docker/completions" ]]; then
   fpath=("$HOME/.docker/completions" $fpath)
 fi
 
+# Tool completions installed as lazy-autoloaded fpath functions. uv ships a
+# ~6800-line completion; autoloading defers that parse until first use instead
+# of sourcing it into every shell. Generated before compinit so it registers.
+fpath=("${XDG_DATA_HOME}/zsh/completions" $fpath)
+ensure_completion uv uv generate-shell-completion zsh
+ensure_completion uvx uvx --generate-shell-completion zsh
+
 autoload -Uz compinit
 ensure_dir_exists "${XDG_CACHE_HOME}/zsh"
 
@@ -466,15 +490,6 @@ zstyle ':completion:*' menu select
 
 # Show dotfiles in tab completion
 setopt GLOB_DOTS
-
-# Tool-specific completions (deferred when available)
-if (( $+functions[zsh-defer] )); then
-  zsh-defer -c 'cache_eval uvx uvx --generate-shell-completion zsh'
-  zsh-defer -c 'cache_eval uv uv generate-shell-completion zsh'
-else
-  cache_eval uvx uvx --generate-shell-completion zsh
-  cache_eval uv uv generate-shell-completion zsh
-fi
 
 # Google Cloud SDK completions
 if [[ -n "$GCP_SDK_PATH" && -d "$GCP_SDK_PATH" ]]; then


### PR DESCRIPTION
## Follow-up to #53

After #53, opening a new terminal felt better but not excellent. Measured the remaining post-prompt deferred batch: ~0.15s warm, and **uv's completion alone is 6807 lines** — by far the largest single chunk, sourced into every shell even from cache. That parse is what still buffered the first keystrokes (and it's much worse cold, when the lines aren't in the inode cache).

## Change

uv/uvx completions are already autoload-ready (`#compdef uv` header + the self-installing `if [ "$funcstack[1]" = "_uv" ]` tail), so instead of sourcing them, install them as `_uv`/`_uvx` in an fpath dir and let compinit register them. The body then loads **lazily on the first `uv <TAB>`**, not on every shell.

- New `ensure_completion` helper: writes the completion to `~/.local/share/zsh/completions/_<cmd>`, regenerates only when the binary changes, and drops the compdump on regen so the next compinit re-registers it.
- Runs before compinit; removed the old deferred `cache_eval uv/uvx` block.

## Impact

- Per-shell sourced lines: **~8100 → ~1050**
- Warm deferred batch: **0.15s → 0.07s** (cold win is larger)
- `uv <TAB>` still completes — verified compinit registers `_comps[uv]=_uv` and the body stays a lazy autoload (not parsed at startup)

## Verification

- `zsh -n` parses; faithful end-to-end test confirms generate → compinit registration → lazy autoload, and the warm path skips regen and keeps `compinit -C`

After applying, the stale `~/.cache/zsh/{uv,uvx}-init.zsh` files from #53 are orphaned and safe to `rm`. **Still needs the real new-terminal feel test.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)