### PR TITLE
skills: restore wishlist and bootstrap installer (slim, manual)

### DIFF
--- a/.chezmoiremove
+++ b/.chezmoiremove
@@ -1,7 +1,5 @@
 .local/bin/wallpaper-info
 .agents/skills.list
-.agents/skills.wishlist
-.local/bin/skills-bootstrap
 .local/bin/skills-manifest
 .claude/skills/notify-master
 .local/bin/notify-master

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Mise tools auto-upgrade daily in the background via `.zshrc`.
 | `.config/gh/` | GitHub CLI |
 | `.config/bat/`, `.config/lazygit/` | CLI tools |
 | `.claude/` | Claude Code settings and hooks |
-| `.agents/` | Shared `AGENTS.md`/`CLAUDE.md`, consumed by every agent via symlink |
+| `.agents/` | Shared `AGENTS.md`/`CLAUDE.md` and the agent-skills wishlist, consumed by every agent via symlink |
 | `.docker/` | Docker daemon config |
 | `.ssh/` | SSH config (no keys) |
 | `.vimrc` | Vim config |
@@ -358,6 +358,39 @@ All plugins except zsh-defer are lazy-loaded with `kind:defer`.
 | `gnb <branch>` | Checkout main, pull, create new branch |
 | `cdm` | cd to main worktree of current git repo |
 | `rep [name]` | cd to `~/repos` or `~/repos/<name>` |
+
+## Agent skills
+
+[Agent skills](https://skills.sh) are reusable bundles of procedural knowledge
+that coding agents load on demand. They're installed globally into every agent on
+the machine — Claude Code, Codex, Gemini CLI, GitHub Copilot, OpenCode — with the
+`skills` CLI (run via `bunx`).
+
+The curated set lives in `~/.agents/skills.wishlist`, a chezmoi-managed plain-text
+list that is the single source of truth. Each line is a source repo plus the skills
+to pull from it:
+
+```
+anthropics/skills --skill frontend-design
+pbakaus/impeccable --skill impeccable --skill layout --skill shape
+stripe/ai --skill stripe-best-practices --skill stripe-projects --skill upgrade-stripe
+```
+
+Install (or reinstall) the whole set with the bootstrap script — it reads the
+wishlist and runs `bunx skills add` for each entry. It's idempotent, so re-running
+just refreshes:
+
+```bash
+skills-bootstrap
+```
+
+To add a skill: append a line to the wishlist (`cmc` to `chezmoi cd`, edit
+`dot_agents/skills.wishlist`, commit), `chezmoi apply`, then run `skills-bootstrap`.
+Nothing runs automatically — installs happen only when you invoke the script.
+
+Installed skills and the `~/.agents/.skill-lock.json` lockfile are bunx's runtime
+state, deliberately **not** chezmoi-managed; the wishlist is what reproduces the set
+on a new machine.
 
 ## Profiles
 

--- a/dot_agents/skills.wishlist
+++ b/dot_agents/skills.wishlist
@@ -1,0 +1,5 @@
+alltuner/skills --skill vacant
+anthropics/skills --skill frontend-design
+microsoft/azure-skills --skill microsoft-foundry
+pbakaus/impeccable --skill impeccable --skill layout --skill shape
+stripe/ai --skill stripe-best-practices --skill stripe-projects --skill upgrade-stripe

--- a/dot_local/bin/executable_skills-bootstrap
+++ b/dot_local/bin/executable_skills-bootstrap
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# ABOUTME: Install every agent skill listed in ~/.agents/skills.wishlist into all agents.
+# ABOUTME: Idempotent — bunx refreshes existing skills, so it is safe to re-run.
+set -euo pipefail
+
+wishlist="${HOME}/.agents/skills.wishlist"
+
+if ! command -v bunx >/dev/null 2>&1; then
+  echo "skills-bootstrap: bunx not found; skipping" >&2
+  exit 0
+fi
+
+if [ ! -f "${wishlist}" ]; then
+  echo "skills-bootstrap: no wishlist at ${wishlist}" >&2
+  exit 0
+fi
+
+while IFS= read -r line; do
+  case "${line}" in
+    ''|\#*) continue ;;
+  esac
+  # Word-split the entry ("owner/repo --skill a --skill b") into bunx arguments.
+  # shellcheck disable=SC2086
+  bunx skills add ${line} \
+    --agent claude-code \
+    --agent codex \
+    --agent gemini-cli \
+    --agent github-copilot \
+    --agent opencode \
+    -g -y
+done < "${wishlist}"


### PR DESCRIPTION
Brings back a slim, manual version of the agent-skills setup for the cross-machine use case: keep the same global skill set reproducible across machines, without the automation that was removed in #55.

## Restored
- `dot_agents/skills.wishlist` — plain-text source of truth (one source repo + skills per line)
- `dot_local/bin/executable_skills-bootstrap` — idempotent installer that reads the wishlist and runs `bunx skills add ... -g` into every agent (Claude Code, Codex, Gemini CLI, GitHub Copilot, OpenCode)

## Deliberately NOT restored
- the `run_onchange` install hook — no automatic installs on `chezmoi apply`
- the `skills-add` zsh helper
- the daily background `bunx skills update`

Installs now happen **only** when you run `skills-bootstrap` by hand.

## Also
- `README.md`: documents the manual workflow
- `.chezmoiremove`: drops the cleanup entries added in #55 for these two files (they're back, so they shouldn't be removed on apply)

## Why this over `skills-lock.json`
The CLI's `experimental_install` only installs to "universal" agents (those reading `.agents/skills`) and is cwd-scoped — it won't populate Claude Code's `~/.claude/skills`. A wishlist of `skills add ... -g --agent ...` is the only approach that reproduces the full global set across machines for all agents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)