### PR TITLE
skills: stop bunx from eating the wishlist via shared stdin

### DIFF
--- a/dot_local/bin/executable_skills-bootstrap
+++ b/dot_local/bin/executable_skills-bootstrap
@@ -15,7 +15,10 @@ if [ ! -f "${wishlist}" ]; then
   exit 0
 fi
 
-while IFS= read -r line; do
+# Read the wishlist on fd 3 so bunx keeps the real stdin; otherwise bunx
+# drains the rest of the file through its prompts and only the first entry
+# installs.
+while IFS= read -r line <&3; do
   case "${line}" in
     ''|\#*) continue ;;
   esac
@@ -28,4 +31,4 @@ while IFS= read -r line; do
     --agent github-copilot \
     --agent opencode \
     -g -y
-done < "${wishlist}"
+done 3< "${wishlist}"


### PR DESCRIPTION
## Symptom
`skills-bootstrap` installed only the **first** wishlist entry (`vacant`). The remaining lines showed up as garbage fed into bunx's prompts — `anthropics` even lost its leading `a` (consumed as a keypress).

## Root cause
The loop ran with `done < "${wishlist}"`, making the wishlist file the loop's stdin. `bunx skills add` reads that same stdin for its interactive prompts and drained the rest of the file on the first iteration, so iterations 2–5 never happened. The `-y` flag did not fully suppress the reads.

## Fix
Read the wishlist on file descriptor 3 (`done 3< … ; read … <&3`), leaving `bunx` the real stdin. Verified with a stub that drains stdin like bunx does: all 5 entries now process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)