### PR TITLE
skills: drop deleted layout/shape, add shadcn to wishlist

### DIFF
--- a/dot_agents/skills.wishlist
+++ b/dot_agents/skills.wishlist
@@ -2,4 +2,5 @@ alltuner/skills --skill vacant
 anthropics/skills --skill frontend-design
 microsoft/azure-skills --skill microsoft-foundry
 pbakaus/impeccable --skill impeccable
+shadcn/ui --skill shadcn
 stripe/ai --skill stripe-best-practices --skill stripe-projects --skill upgrade-stripe

--- a/dot_agents/skills.wishlist
+++ b/dot_agents/skills.wishlist
@@ -1,5 +1,5 @@
 alltuner/skills --skill vacant
 anthropics/skills --skill frontend-design
 microsoft/azure-skills --skill microsoft-foundry
-pbakaus/impeccable --skill impeccable --skill layout --skill shape
+pbakaus/impeccable --skill impeccable
 stripe/ai --skill stripe-best-practices --skill stripe-projects --skill upgrade-stripe


### PR DESCRIPTION
Two wishlist corrections so it accurately reproduces the global skill set on a fresh machine.

## Drop `layout` and `shape`
`pbakaus/impeccable` now ships only the `impeccable` skill — `layout` and `shape` were deleted upstream (folded into `impeccable`). Confirmed by cloning the current repo: every `SKILL.md` declares `name: impeccable`.

This is why `bunx skills ls -g` showed `layout`/`shape` as Claude-Code-only orphans at `~/.claude/skills/` (stale April standalone copies) while everything else is universal at `~/.agents/skills/`: the bootstrap couldn't fetch them because they no longer exist upstream. The stale local copies are removed separately via the `bunx skills update -g` prompt.

## Add `shadcn`
`shadcn` was installed globally (`~/.agents/skills/shadcn`, source `shadcn/ui`) but absent from the wishlist, so it would not reproduce on a fresh machine. Declared as `shadcn/ui --skill shadcn` (source confirmed from the lockfile).

## Result
```
alltuner/skills --skill vacant
anthropics/skills --skill frontend-design
microsoft/azure-skills --skill microsoft-foundry
pbakaus/impeccable --skill impeccable
shadcn/ui --skill shadcn
stripe/ai --skill stripe-best-practices --skill stripe-projects --skill upgrade-stripe
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)