### PR TITLE
skills: silence chezmoi diff noise in skills-add

### DIFF
--- a/dot_local/bin/executable_skills-add
+++ b/dot_local/bin/executable_skills-add
@@ -77,13 +77,14 @@ awk -v src="${src}" -v add="${skills[*]}" '
   }
   { print }
   END { if (!done) { line = src; for (k = 1; k <= na; k++) line = line " --skill " A[k]; print line } }
-' "${wishlist}" | LC_ALL=C sort > "${tmp}" && mv "${tmp}" "${wishlist}"
+' "${wishlist}" | LC_ALL=C sort > "${tmp}"
 
 # Nothing to do if the skill was already listed.
-if chezmoi git -- diff --quiet -- "${wishlist}"; then
+if cmp -s "${tmp}" "${wishlist}"; then
   echo "skills-add: ${src} (${skills[*]}) already in the wishlist; installed, nothing to commit."
   exit 0
 fi
+mv "${tmp}" "${wishlist}"
 
 # 3. Sync the live copy, then commit + push the wishlist via chezmoi.
 chezmoi apply "${target}"


### PR DESCRIPTION
Follow-up from testing `skills-add` end-to-end (added the `cloudflare` skill — install + sorted wishlist + commit + push all worked).

The run printed a spurious `chezmoi: git: exit status 1`. Cause: the idempotency probe used `chezmoi git -- diff --quiet`, and chezmoi surfaces that diagnostic whenever the wrapped git exits non-zero — which is exactly the normal "there's a change to commit" case. The logic was correct; it just looked alarming.

Fix: regenerate the wishlist to a temp file and compare it against the current file with `cmp -s` before moving it into place. Same short-circuit when the skill is already listed, no chezmoi git invocation for the check, no noise.

shellcheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)