### PR TITLE
bubu: pass --yes to brew upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ All plugins except zsh-defer are lazy-loaded with `kind:defer`.
 |---|---|
 | `cma` | `chezmoi add` |
 | `cmc` | `chezmoi cd` |
-| `bubu` | `brew update && brew upgrade` |
+| `bubu` | `brew update && brew upgrade --yes` |
 
 ### Shell functions
 

--- a/dot_zshrc
+++ b/dot_zshrc
@@ -402,7 +402,7 @@ alias ghp='gh pr list --web'
 alias ghpr='gh pr view --web'
 
 # System maintenance
-command_exists brew && alias bubu='brew update && brew upgrade'
+command_exists brew && alias bubu='brew update && brew upgrade --yes'
 
 # Docker
 alias dps='docker ps --format "table {{.Names}}\t{{.Status}}\t{{.Ports}}"'


### PR DESCRIPTION
Homebrew's recent release made `brew upgrade` prompt for confirmation by default (ask mode), so `bubu` would hang waiting for input. Adding `--yes` keeps it non-interactive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)