### PR TITLE
worktree hooks: handle namespaced (slash) worktree names

### DIFF
--- a/private_dot_claude/hooks/_common.sh
+++ b/private_dot_claude/hooks/_common.sh
@@ -91,6 +91,21 @@ resolve_repo_root() {
 	echo "${root:-$from}"
 }
 
+# Print every registered worktree as "<path>\t<branch>", one per line, with the
+# branch stripped of its refs/heads/ prefix (empty for detached/bare entries).
+# Authoritative via `git worktree list --porcelain`, so namespaced worktree
+# paths (e.g. .claude/worktrees/dig/<slug>) survive intact where a basename or
+# fixed-depth glob would mangle them.
+# $1: repo root
+list_worktrees() {
+	local repo="$1"
+	git -C "$repo" worktree list --porcelain 2>/dev/null | awk '
+		/^worktree / { if (wt != "") print wt "\t" b; wt = substr($0, 10); b = "" }
+		/^branch /   { b = substr($0, 8); sub(/^refs\/heads\//, "", b) }
+		END          { if (wt != "") print wt "\t" b }
+	'
+}
+
 # Print the repo's default branch name (no refs/ prefix).
 # Prefers origin/HEAD's symbolic ref, falls back to local main, then master.
 # Empty output means no default branch could be determined.
@@ -320,10 +335,16 @@ clean_stale_worktrees() {
 	local stale_dir stale_name stale_branch upstream has_upstream should_clean reason
 	local merged_pr wt_created age_hours unique_commits
 	local removed=0 kept=0 scanned=0
-	for stale_dir in "$dir"/*/; do
-		[ -d "$stale_dir" ] || continue
-		stale_name=$(basename "$stale_dir")
-		stale_branch="worktree-$stale_name"
+	# Enumerate worktrees authoritatively from git rather than globbing a fixed
+	# depth, so namespaced worktrees (.claude/worktrees/dig/<slug>) are visible
+	# and their real branch (with slashes) comes straight from git.
+	while IFS=$'\t' read -r stale_dir stale_branch; do
+		case "$stale_dir" in
+			"$dir"/*) ;;
+			*) continue ;;
+		esac
+		[ -d "$stale_dir" ] && [ -n "$stale_branch" ] || continue
+		stale_name="${stale_dir#"$dir"/}"
 		[ "$stale_name" = "$skip" ] && continue
 		scanned=$((scanned + 1))
 
@@ -399,7 +420,7 @@ clean_stale_worktrees() {
 		else
 			kept=$((kept + 1))
 		fi
-	done
+	done < <(list_worktrees "$repo")
 	if [ "$scanned" -gt 0 ]; then
 		log "✓ Cleanup loop: scanned $scanned, removed $removed, kept $kept"
 	fi

--- a/private_dot_claude/hooks/executable_worktree-remove.sh
+++ b/private_dot_claude/hooks/executable_worktree-remove.sh
@@ -6,8 +6,12 @@ source "$(dirname "$0")/_common.sh"
 
 INPUT=$(cat)
 
-# WorktreeRemove payload has worktree_path (not name)
-NAME=$(echo "$INPUT" | jq -r '.worktree_path // empty' | xargs basename 2>/dev/null || true)
+# WorktreeRemove payload carries worktree_path (no name). Derive the namespaced
+# name by stripping the worktrees prefix — basename would drop the namespace
+# segment (dig/<slug> -> <slug>) and target a path/branch that doesn't exist.
+WT_PATH=$(echo "$INPUT" | jq -r '.worktree_path // empty')
+NAME="${WT_PATH%/}"
+NAME="${NAME##*/.claude/worktrees/}"
 if [ -z "$NAME" ]; then
 	echo "[$(date '+%H:%M:%S')] [remove] ERROR: Could not extract worktree name" \
 		>> "/tmp/worktree-hooks-$(date '+%Y-%m-%d').log"
@@ -15,8 +19,13 @@ if [ -z "$NAME" ]; then
 fi
 
 REPO_ROOT=$(resolve_repo_root "$CLAUDE_PROJECT_DIR")
+# Rebuild the path from the canonical repo root rather than the payload, which
+# may carry an uncanonicalized path that won't match git's records.
 WORKTREE_DIR="$REPO_ROOT/.claude/worktrees/$NAME"
-BRANCH="worktree-$NAME"
+# Branch comes straight from git's record of the worktree; fall back to the
+# create-hook convention if the worktree is no longer registered.
+BRANCH=$(list_worktrees "$REPO_ROOT" | awk -F'\t' -v p="$WORKTREE_DIR" '$1 == p { print $2; exit }')
+[ -n "$BRANCH" ] || BRANCH="worktree-$NAME"
 
 TRANSCRIPT=$(echo "$INPUT" | jq -r '.transcript_path // empty')
 CURRENT_SESSION=""


### PR DESCRIPTION
## Summary

Fixes #64. Worktree hooks assumed a worktree's name was a single path segment under `.claude/worktrees/`. Slash-containing names (namespaced worktrees like `dig/<slug>`, used by the `digs` repo) broke two things:

1. **`worktree-remove.sh` silently no-op'd** — it rebuilt the name with `basename`, dropping the `dig/` segment, so it targeted a path/branch that didn't exist while `ExitWorktree` reported success.
2. **`clean_stale_worktrees` never swept them** — its one-level glob saw the namespace dir (`dig`) as a single worktree and kept it forever, so merged namespaced worktrees piled up (~18 in `digs`).

## Fix

Per the issue's suggested direction, enumerate worktrees authoritatively from `git worktree list --porcelain` (path + branch) instead of `basename`/depth guesswork:

- New `list_worktrees` helper in `_common.sh` parses porcelain into `<path>\t<branch>` lines.
- The remove hook derives the namespaced name by stripping the `.claude/worktrees/` prefix, rebuilds the path from the canonical repo root (the payload path may be uncanonicalized and not match git's records), and looks the branch up from porcelain (falling back to the `worktree-<name>` create-hook convention if the worktree is already gone).
- `clean_stale_worktrees` drives its loop off `list_worktrees`, filtering to paths under the worktrees dir, so namespaced worktrees are visible and their real (slashed) branch comes straight from git.

Flat names are unaffected.

## Testing

Local end-to-end tests against throwaway repos with a fake origin:

- Remove hook on a squash-merged `dig/foo`: logs `Removed worktree: dig/foo`, directory and branch both gone (previously logged "directory not found").
- Stale sweep on a pushed-then-remote-gone `dig/alpha`: logs `Cleaning stale worktree: dig/alpha (remote branch gone, all commits already in main)`, swept.
- Never-pushed worktrees with unique commits and flat unmerged worktrees still preserved (existing behavior unchanged).
- `shellcheck -x` clean on all three hook files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)