### PR TITLE
worktree sweep: detect squash-merged worktrees (#68)

### DIFF
--- a/private_dot_claude/hooks/_common.sh
+++ b/private_dot_claude/hooks/_common.sh
@@ -343,11 +343,15 @@ worktree_has_active_session() {
 
 # Iterate over $repo/.claude/worktrees/* and remove any that are stale.
 # A worktree is stale when:
+#   - its work is already in $base_ref (squash/rebase merged) or a merged PR
+#     exists for it — the same check the targeted remove path uses, so the
+#     sweep mops up merged worktrees the explicit removal skipped (remote branch
+#     lingering, or pushed under a de-prefixed head), OR
 #   - its branch had an upstream and the remote branch is now gone (and, if
 #     $require_pr=yes, a merged PR exists for it), OR
 #   - it was never pushed, has no unique commits beyond $base_ref, and was
 #     created more than 24 hours ago.
-# Worktrees with unpushed unique commits are always preserved.
+# Worktrees with unpushed, unmerged unique commits are always preserved.
 #
 # $1 repo            — repo root
 # $2 base_ref        — branch the unique-commit count is measured against,
@@ -383,11 +387,13 @@ clean_stale_worktrees() {
 		# inherits origin/<default> as its upstream via branch.autoSetupMerge
 		# (on by default). That is NOT evidence the branch was ever pushed —
 		# so only count an upstream that points at the branch's own remote ref.
-		# Otherwise a fresh, never-pushed worktree takes the "pushed then remote
-		# gone" path, looks squash-merged (no unique commits vs base), and gets
-		# deleted mid-run.
+		# The push may target a de-prefixed head (worktree-dig/<slug> pushes to
+		# origin/dig/<slug>), so accept that ref too. Otherwise a fresh,
+		# never-pushed worktree takes the "pushed then remote gone" path, looks
+		# squash-merged (no unique commits vs base), and gets deleted mid-run.
 		upstream=$(git -C "$repo" for-each-ref --format='%(upstream)' "refs/heads/$stale_branch" 2>/dev/null)
-		if [ "$upstream" = "refs/remotes/origin/$stale_branch" ]; then
+		if [ "$upstream" = "refs/remotes/origin/$stale_branch" ] \
+			|| [ "$upstream" = "refs/remotes/origin/${stale_branch#worktree-}" ]; then
 			has_upstream="$upstream"
 		else
 			has_upstream=""
@@ -395,7 +401,32 @@ clean_stale_worktrees() {
 		should_clean=false
 		reason=""
 
-		if [ -n "$has_upstream" ]; then
+		# Primary check, mirroring the targeted remove path: if the branch's
+		# work is already in $base_ref (squash/rebase merged) or a merged PR
+		# exists, it's safe to clean regardless of upstream/remote state. This
+		# catches merged worktrees that linger because their remote branch was
+		# never deleted, or because they pushed under a de-prefixed head, so the
+		# upstream/age heuristics below never opened the gate. Guard on
+		# unique_commits>0: branch_is_squash_merged_into reports a zero-commit
+		# branch as merged (empty `git cherry`), which would sweep a fresh
+		# worktree that has no work yet.
+		unique_commits=$(unique_commits_against "$repo" "$base_ref" "$stale_branch")
+		if [ "$unique_commits" -gt 0 ]; then
+			if branch_is_squash_merged_into "$repo" "$base_ref" "$stale_branch"; then
+				should_clean=true
+				reason="all commits already in $base_ref (squash/rebase merged)"
+			else
+				merged_pr=$(merged_pr_for_branch "$repo" "$stale_branch")
+				if [ -n "$merged_pr" ]; then
+					should_clean=true
+					reason="PR #$merged_pr merged"
+				fi
+			fi
+		fi
+
+		# Fallback heuristics, only when the merge check above didn't already
+		# decide. These guard never-pushed local work from being swept.
+		if [ "$should_clean" != true ] && [ -n "$has_upstream" ]; then
 			# Pushed at some point. If the remote branch is gone, the work is
 			# very likely merged. Verify in this order:
 			#   1. git cherry — portable, catches squash/rebase merges
@@ -418,7 +449,7 @@ clean_stale_worktrees() {
 					reason="remote branch gone"
 				fi
 			fi
-		else
+		elif [ "$should_clean" != true ]; then
 			# Never pushed. Only clean if it's old AND has no unique commits,
 			# so we never silently throw away in-progress local work. A 0
 			# timestamp means the creation time is unknown (no reflog); treat
@@ -429,7 +460,6 @@ clean_stale_worktrees() {
 			if [ "$wt_created" -le 0 ]; then
 				log "⏭ Keeping stale worktree: $stale_name (unknown creation time)"
 			elif [ "$age_hours" -ge 24 ]; then
-				unique_commits=$(unique_commits_against "$repo" "$base_ref" "$stale_branch")
 				if [ "$unique_commits" -eq 0 ]; then
 					should_clean=true
 					reason="no upstream, no unique commits, ${age_hours}h old"

--- a/private_dot_claude/hooks/executable_session-end-update-main.sh
+++ b/private_dot_claude/hooks/executable_session-end-update-main.sh
@@ -49,3 +49,11 @@ fi
 
 update_default_branch "$REPO_ROOT" "$DEFAULT_BRANCH"
 log "✓ Updated $DEFAULT_BRANCH in $REPO_ROOT"
+
+# Opportunistically sweep merged/stale sibling worktrees. `claude agents` /
+# central-coordinator teardowns skip WorktreeRemove, so without this their
+# merged worktrees never get cleaned. Skip the worktree this session ran in —
+# its teardown is the harness's job, and the still-live session would guard it
+# anyway — and require merge evidence before removing (defensive).
+SKIP_NAME="${CWD#"$REPO_ROOT/.claude/worktrees/"}"
+clean_stale_worktrees "$REPO_ROOT" "$DEFAULT_BRANCH" "$SKIP_NAME" "yes"


### PR DESCRIPTION
## Summary

`clean_stale_worktrees` (the opportunistic sweep) never consulted the squash-merge / merged-PR helpers that the *targeted* remove path already uses, so squash-merged worktrees that weren't the explicit removal target piled up indefinitely (issue #68).

Two dead ends trapped them:
- **has-upstream path** only acts once the remote branch is *gone*; if the remote lingers (auto-delete off), the squash check is never reached.
- **never-pushed path** keeps anything with unique commits — and a squash merge always leaves the branch's commits unmerged by SHA. De-prefixed dig pushes (`worktree-dig/<slug>` → `origin/dig/<slug>`) also misclassified as never-pushed because the upstream-equality check from #37 only matched `origin/<same-name>`.

## Changes

- **Primary fix:** add a merge check up front in `clean_stale_worktrees`, mirroring the targeted remove path (`worktree-remove.sh:67-70`): clean when the work is already in `base_ref` (squash/rebase merged) or a merged PR exists — regardless of upstream/remote state. Guarded by `unique_commits > 0`, because `branch_is_squash_merged_into` reports a zero-commit branch as merged (empty `git cherry`), which would otherwise sweep a fresh worktree. The existing upstream-gone / age+unique-commits heuristics remain as the fallback, so #37's "don't delete fresh worktrees" guarantee holds.
- Accept the de-prefixed push target (`origin/${branch#worktree-}`) when classifying upstream, so pushed dig branches are recognized.
- Run the sweep from `session-end-update-main.sh` too, so `claude agents` / central-coordinator teardowns that skip `WorktreeRemove` get their merged worktrees cleaned (the #24 gap). Skips the worktree the session ran in and requires merge evidence.

## Testing

shellcheck-clean, `/bin/bash -n` (bash 3.2) clean. A behavioral harness builds a real origin + worktrees and asserts:

| case | before | after |
|---|---|---|
| squash-merged, remote present, correct upstream | kept (bug) | **swept** |
| squash-merged, pushed to de-prefixed `origin/dig/<slug>` | kept (bug) | **swept** |
| fresh zero-commit worktree | kept | kept |
| genuinely unmerged unique commit | kept | kept |

Against the unpatched hooks the harness reports `removed 0, kept 4` (reproducing the bug); patched it sweeps the 2 merged and preserves the 2 fresh/unmerged.

Closes #68.

🤖 Generated with [Claude Code](https://claude.com/claude-code)