### PR TITLE
agent-browser: gate headed on desktop session + auto-heal stale lock

### DIFF
--- a/dot_agent-browser/config.json.tmpl
+++ b/dot_agent-browser/config.json.tmpl
@@ -1,6 +1,6 @@
 {
   "$schema": "https://agent-browser.dev/schema.json",
-  "headed": true,
+  "headed": false,
   "executablePath": "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
   "profile": "{{ .chezmoi.homeDir }}/.agent-browser/profile"
 }

--- a/dot_agents/AGENTS.md
+++ b/dot_agents/AGENTS.md
@@ -239,17 +239,29 @@ Core loop:
 
 Session state persists per project automatically (a PreToolUse hook sets
 `AGENT_BROWSER_SESSION_NAME` from the repo root), so cookies and logins survive
-across commands.
+across commands. The same hook gates the window (headed only in an interactive
+desktop session; headless in background jobs, SSH, and non-GUI contexts, so
+automation never spawns stray Chrome windows) and clears a stale Chrome lock
+left by a crashed session so the next launch isn't wedged.
 
 Anti-detection posture is set globally in `~/.agent-browser/config.json`: real
-Google Chrome (not the bundled Chrome for Testing), headed, and a dedicated
-persistent profile (`~/.agent-browser/profile`) that warms a genuine fingerprint
-and its own logins over time. This defeats basic detection only — agent-browser
-does no local fingerprint spoofing. For sites with hard anti-bot (Cloudflare,
-DataDome), use a cloud stealth provider instead (`-p browserless` with
+Google Chrome (not the bundled Chrome for Testing) and a dedicated persistent
+profile (`~/.agent-browser/profile`) that warms a genuine fingerprint and its
+own logins over time. This defeats basic detection only — agent-browser does no
+local fingerprint spoofing. For sites with hard anti-bot (Cloudflare, DataDome),
+use a cloud stealth provider instead (`-p browserless` with
 `BROWSERLESS_STEALTH=true`, or `-p kernel` with `KERNEL_STEALTH=true`; both need a
-provider API key). Headed needs a graphical login session, so it won't render in
-headless or pure-SSH contexts.
+provider API key).
+
+Running agent-browser by hand outside Claude defaults to headless (the config),
+since the headed gating lives in the hook; pass `--headed` (or
+`AGENT_BROWSER_HEADED=true`) for a window. All sessions share the one profile
+dir, and Chrome allows only one process per profile, so two repos driving the
+browser at the same time collide on its lock. That's rare, so the shared profile
+stays the default (it keeps one warm fingerprint and shared logins). If you
+genuinely need concurrent sessions, give one its own dir with
+`AGENT_BROWSER_PROFILE=~/.agent-browser/profiles/<name>` (it then warms its own
+fingerprint and won't share logins).
 
 Reach for Playwright MCP or chrome-devtools-mcp instead when you need what
 agent-browser lacks: network interception, PDF generation, or a non-Chromium

--- a/private_dot_claude/hooks/executable_agent-browser-session.sh
+++ b/private_dot_claude/hooks/executable_agent-browser-session.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# ABOUTME: PreToolUse hook for agent-browser: injects a per-project session name and
-# ABOUTME: clears a stale Chrome SingletonLock so a crashed session can't wedge later launches.
+# ABOUTME: PreToolUse hook for agent-browser: injects a per-project session name, gates the
+# ABOUTME: headed window to interactive desktop sessions, and clears a stale Chrome lock.
 set -euo pipefail
 
 INPUT=$(cat)
@@ -35,7 +35,19 @@ MAIN_ROOT=$(dirname "$MAIN_GIT")
 SESSION_NAME=$(basename "$MAIN_ROOT" | tr -cs '[:alnum:]-' '-' | sed 's/^-//;s/-$//')
 [ -n "$SESSION_NAME" ] || exit 0
 
-jq -n --arg cmd "AGENT_BROWSER_SESSION_NAME=$SESSION_NAME $COMMAND" '{
+PREFIX="AGENT_BROWSER_SESSION_NAME=$SESSION_NAME"
+
+# Show a real browser window only in an interactive desktop session. Background jobs,
+# SSH, and non-GUI contexts default to headless so they never spawn stray windows on
+# someone's screen. An explicit headed choice already in the command always wins.
+if [[ "$COMMAND" != *AGENT_BROWSER_HEADED* && "$COMMAND" != *--headed* ]] \
+   && [ -z "${CLAUDE_JOB_DIR:-}" ] \
+   && [ -z "${SSH_CONNECTION:-}" ] && [ -z "${SSH_TTY:-}" ] \
+   && [ "$(launchctl managername 2>/dev/null)" = "Aqua" ]; then
+  PREFIX="$PREFIX AGENT_BROWSER_HEADED=true"
+fi
+
+jq -n --arg cmd "$PREFIX $COMMAND" '{
   hookSpecificOutput: {
     hookEventName: "PreToolUse",
     updatedInput: { command: $cmd }

--- a/private_dot_claude/hooks/executable_agent-browser-session.sh
+++ b/private_dot_claude/hooks/executable_agent-browser-session.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# ABOUTME: PreToolUse hook that injects AGENT_BROWSER_SESSION_NAME into agent-browser commands.
-# ABOUTME: Derives session name from the main git repo root (not worktree) for per-project persistence.
+# ABOUTME: PreToolUse hook for agent-browser: injects a per-project session name and
+# ABOUTME: clears a stale Chrome SingletonLock so a crashed session can't wedge later launches.
 set -euo pipefail
 
 INPUT=$(cat)
@@ -13,6 +13,14 @@ COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
 
 # agent-browser must be installed
 command -v agent-browser >/dev/null 2>&1 || exit 0
+
+# Clear a stale Chrome SingletonLock so a crashed session doesn't wedge every later
+# launch. All sessions share one profile (one Chrome per user-data-dir); remove the
+# lock only when no live process still holds it, so we never disturb a running browser.
+PROFILE="$HOME/.agent-browser/profile"
+if [ -L "$PROFILE/SingletonLock" ] && ! pgrep -f "$PROFILE" >/dev/null 2>&1; then
+  rm -f "$PROFILE"/Singleton{Lock,Cookie,Socket}
+fi
 
 # Already has a session name set — don't override
 [[ "$COMMAND" == *AGENT_BROWSER_SESSION_NAME* ]] && exit 0


### PR DESCRIPTION
Fixes the agent-browser headed/lock issues found while debugging ~12 Chrome windows spawned from a background job on 2026-06-17.

## #70 — clear orphaned SingletonLock before launch
All sessions share one Chrome profile dir, and Chrome enforces one process per `--user-data-dir` via `SingletonLock`. A session that exits uncleanly leaves a stale lock, and every later launch crash-loops (`Chrome exited before providing DevTools URL`) until someone kills procs and removes the lock by hand. The PreToolUse hook now removes `Singleton{Lock,Cookie,Socket}` when the lock exists but **no live process references the profile path** — so a running browser (including a concurrent cross-repo session) is never disturbed.

## #69 — gate the headed window on an interactive desktop session
`config.json` hard-coded `"headed": true`, so background jobs / SSH / CI inherited a desk-only setting. Headed-vs-headless is a **runtime** condition, so it can't live in the chezmoi template (evaluated once at apply time). The config now defaults to **headless**, and the hook re-enables headed only for an interactive desktop session (no `CLAUDE_JOB_DIR`, no SSH, `launchctl managername == Aqua`). An explicit `--headed` / `AGENT_BROWSER_HEADED` always wins.

A GUI-session check alone would **not** have caught the reported bug: a background job inherits the desktop's Aqua session, so `CLAUDE_JOB_DIR` is the real discriminator (verified on this machine).

## #71 — per-session profile isolation: closing as wontfix
Blanket per-session profiles would destroy the whole point of the shared profile (one warm fingerprint + shared logins). The collision it prevents only bites on *simultaneous* cross-repo driving (rare), and the stale-lock case is auto-healed by #70. `AGENTS.md` documents the manual escape hatch (`AGENT_BROWSER_PROFILE=~/.agent-browser/profiles/<name>`) for when concurrency is genuinely needed. Will close #71 as wontfix once this merges.

## Verification
- Hook syntax checked under both `env bash` and `/bin/bash` 3.2.
- Headed gating tested across contexts: background job → headless; simulated interactive desktop → `AGENT_BROWSER_HEADED=true`; SSH → headless; explicit `--headed` → not double-injected.
- Lock heal unit-tested: orphaned lock → removed; lock held by a live process → preserved.
- Config template renders valid JSON with `headed: false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)