### PR TITLE
guard session-end cleanup sweep so a transient git failure can't fail the hook

### DIFF
--- a/private_dot_claude/hooks/executable_session-end-update-main.sh
+++ b/private_dot_claude/hooks/executable_session-end-update-main.sh
@@ -55,5 +55,13 @@ log "✓ Updated $DEFAULT_BRANCH in $REPO_ROOT"
 # merged worktrees never get cleaned. Skip the worktree this session ran in —
 # its teardown is the harness's job, and the still-live session would guard it
 # anyway — and require merge evidence before removing (defensive).
+#
+# This sweep is best-effort. Its many unguarded git calls can fail transiently
+# when the harness mutates a worktree concurrently (e.g. a session resuming in
+# the same instant), which under `set -e` would abort the hook with a non-zero
+# exit *after* main is already updated — surfacing as a spurious "SessionEnd
+# hook error". The `|| log` both neutralizes `set -e` for this call and records
+# the failure instead of crashing the hook.
 SKIP_NAME="${CWD#"$REPO_ROOT/.claude/worktrees/"}"
-clean_stale_worktrees "$REPO_ROOT" "$DEFAULT_BRANCH" "$SKIP_NAME" "yes"
+clean_stale_worktrees "$REPO_ROOT" "$DEFAULT_BRANCH" "$SKIP_NAME" "yes" \
+	|| log "⚠ Cleanup sweep failed (non-fatal); $DEFAULT_BRANCH already updated"


### PR DESCRIPTION
## Problem

A backgrounded session triggered a spurious "SessionEnd hook error" even though the hook's real work succeeded.

`session-end-update-main.sh` does two things: fast-forward the parent repo's default branch (succeeded, logged `✓ Updated main`), then opportunistically sweep stale sibling worktrees via `clean_stale_worktrees`. That sweep runs under `set -euo pipefail` and makes many **unguarded** git calls per worktree. When the harness mutates a worktree concurrently (observed: the same session resuming/re-attaching in the same second), one of those git calls fails transiently → `set -e` aborts the hook with a non-zero exit *after* main was already updated → Claude surfaces it as a hook error. The failure was confirmed transient (replaying the captured payload with no concurrent activity exits 0).

## Fix

Guard the best-effort sweep with `|| log`. This both neutralizes `set -e` for that call and records the failure instead of crashing the hook. Main is already updated by that point; the sweep is opportunistic (WorktreeRemove handles the normal path).

Verified the construct neutralizes `set -e` (simulated sweep failure → hook exits 0, logs the warning) and the script passes `/bin/bash -n` under macOS bash 3.2.