### PR TITLE
add rtk to brew package manifest

### DIFF
--- a/run_onchange_darwin-install-packages.sh.tmpl
+++ b/run_onchange_darwin-install-packages.sh.tmpl
@@ -84,6 +84,7 @@ brew "tig"                  # git TUI
 # AI / inference tooling
 #
 brew "gemini-cli"           # Google Gemini CLI
+brew "rtk"                  # CLI proxy that minimizes LLM token consumption
 cask "anthropics/tap/ant"   # 'ant' — CLI for the Claude Platform
 cask "copilot-cli"          # GitHub Copilot CLI
 cask "macwhisper"           # local Whisper transcription app


### PR DESCRIPTION
Adds `rtk` to the AI / inference tooling section of the Homebrew package manifest.

`rtk` is a Homebrew formula — a CLI proxy that minimizes LLM token consumption (https://www.rtk-ai.app/). Added as `brew` (not `cask`), verified via `brew info rtk`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)