### PR TITLE
worktrees: cover isolation:worktree subagents via SubagentStart

### DIFF
--- a/private_dot_claude/hooks/executable_session-start-setup.sh
+++ b/private_dot_claude/hooks/executable_session-start-setup.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# ABOUTME: SessionStart hook — runs a repo's own .hooks/workspace-setup.sh inside
-# ABOUTME: a freshly created worktree, so each project owns its dependency setup.
+# ABOUTME: SessionStart/SubagentStart hook — runs a repo's own .hooks/workspace-setup.sh
+# ABOUTME: in a freshly created worktree, so each project owns its dependency setup.
 set -uo pipefail
 
 INPUT=$(cat)
@@ -8,8 +8,9 @@ SOURCE=$(printf '%s' "$INPUT" | jq -r '.source // "startup"')
 CWD=$(printf '%s' "$INPUT" | jq -r '.cwd // empty')
 [ -n "$CWD" ] && cd "$CWD" 2>/dev/null || true
 
-# Only on a fresh start — that is when a new worktree's first session begins.
-# resume/clear/compact continue an already-set-up tree.
+# Run on a fresh start (a new worktree's first session) and on subagent spawns
+# (SubagentStart carries no source, so it defaults through). A SessionStart
+# resume/clear/compact continues an already-set-up tree, so skip those.
 [ "$SOURCE" = "startup" ] || exit 0
 
 git rev-parse --git-dir >/dev/null 2>&1 || exit 0

--- a/private_dot_claude/private_settings.json
+++ b/private_dot_claude/private_settings.json
@@ -167,6 +167,16 @@
         ]
       }
     ],
+    "SubagentStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/session-start-setup.sh"
+          }
+        ]
+      }
+    ],
     "WorktreeRemove": [
       {
         "hooks": [


### PR DESCRIPTION
## What

Wire the existing `SessionStart` dependency dispatcher to `SubagentStart` too, so subagents running in their own isolated worktree (`isolation: "worktree"`) get their deps installed.

## Why

Follow-up to #80. That dispatcher only fired on `SessionStart` (top-level sessions). A subagent with `isolation: worktree` gets a fresh worktree but fires `SubagentStart`, not `SessionStart`, so it came up without `.venv`/`node_modules`.

## No script change (beyond comments)

- `SubagentStart` carries **no `source` field**, so it defaults through the existing `source==startup` gate.
- Its `cwd` is the **subagent's own worktree** (verified below), so the linked-worktree guard and `ROOT_PATH`=main-checkout logic already target the right tree.

## Tested (Claude Code 2.1.195)

Custom `isolation: worktree` subagent, SubagentStart logger + dispatcher wired:

```
SubagentStart payload cwd = .../repo/.claude/worktrees/agent-a730dc1c9b764d478   (its own worktree)
workspace-setup RAN  PWD=.../worktrees/agent-a730...  ROOT_PATH=.../repo  venv=none nm=none
workspace-setup DONE PWD=.../worktrees/agent-a730...  venv=Y nm=Y
persisted worktree -> .venv:Y node_modules:Y
```

So: fires for the worktree subagent, targets the subagent's tree, installs deps with the right `ROOT_PATH`.

## Behavior for non-isolated subagents

They share the parent's cwd. In the primary checkout they skip (linked-worktree guard); in a worktree they re-invoke the project script — a cheap no-op **once the project's `workspace-setup.sh` is idempotent**, which it already needs to be since the dispatcher runs on every fresh start.

## Naming note

The script is still `session-start-setup.sh` but now serves two events. Kept the name to avoid a rename orphan in the live `~/.claude/hooks`; happy to rename to something event-agnostic (e.g. `worktree-setup.sh`) if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
