### PR TITLE
session-end: restore worktree cleanup under native creation

### DIFF
--- a/private_dot_claude/hooks/executable_session-end-update-main.sh
+++ b/private_dot_claude/hooks/executable_session-end-update-main.sh
@@ -1,13 +1,14 @@
 #!/usr/bin/env bash
 # ABOUTME: SessionEnd hook — when a Claude session in a git worktree ends,
-# ABOUTME: fetch + fast-forward the parent repo's default branch.
+# ABOUTME: fast-forward the parent default branch and clean the worktree's state.
 #
-# Why: `claude agents` / central-coordinator agent-mode worktrees are torn
-# down without firing WorktreeRemove, so the existing update_default_branch
-# step that lives in worktree-remove.sh never runs for them. SessionEnd
-# fires reliably for those sessions, so we use it as the backup signal.
-# Idempotent: doubling up with WorktreeRemove on the normal `claude -w`
-# path is fine — a second `git fetch` is a no-op when already current.
+# Why: with native worktree creation (no WorktreeCreate hook) the harness tears
+# worktrees down *before* SessionEnd fires and without firing WorktreeRemove, so
+# by the time this runs the worktree directory is already gone. SessionEnd still
+# fires reliably with the worktree's path in the payload, so it is the one place
+# that can ff the parent default branch and clean the orphaned project dir for
+# these worktrees. Everything is derived from the path string, not the (possibly
+# deleted) directory. Idempotent: doubling up with WorktreeRemove is fine.
 
 set -euo pipefail
 
@@ -16,28 +17,23 @@ source "$(dirname "$0")/_common.sh"
 
 INPUT=$(cat)
 
-# Prefer the payload's cwd; fall back to CLAUDE_PROJECT_DIR. Either is fine —
-# we just need a path inside the (possibly worktree) repo.
+# The worktree's path from the payload. It may already be deleted on disk, so
+# nothing below may depend on the directory existing.
 CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
 [ -n "$CWD" ] || CWD="${CLAUDE_PROJECT_DIR:-}"
-[ -n "$CWD" ] && [ -d "$CWD" ] || exit 0
 
-# Only act when we're inside a *worktree* (not the main checkout). A worktree
-# has its per-worktree GIT_DIR distinct from the shared git_common_dir; in the
-# main checkout those resolve to the same `.git`.
-GIT_DIR=$(git -C "$CWD" rev-parse --git-dir 2>/dev/null) || exit 0
-COMMON_DIR=$(git -C "$CWD" rev-parse --git-common-dir 2>/dev/null) || exit 0
-GIT_DIR_ABS=$(cd "$CWD" && cd "$GIT_DIR" && pwd -P)
-COMMON_DIR_ABS=$(cd "$CWD" && cd "$COMMON_DIR" && pwd -P)
-[ "$GIT_DIR_ABS" != "$COMMON_DIR_ABS" ] || exit 0
-
-# `git worktree list --porcelain` always lists the main worktree first.
-REPO_ROOT=$(git -C "$CWD" worktree list --porcelain 2>/dev/null | head -1 | sed 's/^worktree //')
+# Act only for worktree sessions. Worktrees always live under
+# <repo>/.claude/worktrees/<name>, so the parent repo is the prefix before it.
+case "$CWD" in
+	*/.claude/worktrees/*) ;;
+	*) exit 0 ;;
+esac
+REPO_ROOT="${CWD%%/.claude/worktrees/*}"
+NAME="${CWD#"$REPO_ROOT/.claude/worktrees/"}"
 [ -n "$REPO_ROOT" ] && [ -d "$REPO_ROOT" ] || exit 0
 
 setup_logging "[session-end]"
 
-NAME=$(basename "$CWD")
 log "--- SessionEnd in worktree: $NAME (repo: $REPO_ROOT) ---"
 log_quiet "    payload: $(jq -c . <<< "$INPUT" 2>/dev/null || echo "$INPUT" | tr '\n' ' ')"
 
@@ -50,11 +46,20 @@ fi
 update_default_branch "$REPO_ROOT" "$DEFAULT_BRANCH"
 log "✓ Updated $DEFAULT_BRANCH in $REPO_ROOT"
 
-# Opportunistically sweep merged/stale sibling worktrees. `claude agents` /
-# central-coordinator teardowns skip WorktreeRemove, so without this their
-# merged worktrees never get cleaned. Skip the worktree this session ran in —
-# its teardown is the harness's job, and the still-live session would guard it
-# anyway — and require merge evidence before removing (defensive).
+# Native removal deletes the worktree before this hook and never fires
+# WorktreeRemove, so the worktree's ~/.claude/projects/ dir is orphaned. Clean it
+# only once the worktree is actually gone — a kept worktree keeps its dir.
+if [ ! -d "$CWD" ]; then
+	WT_PROJECT="$HOME/.claude/projects/$(sanitize_path "$CWD")"
+	if [ -d "$WT_PROJECT" ]; then
+		rm -rf "$WT_PROJECT" && log "✓ Removed worktree project config: $(basename "$WT_PROJECT")"
+	fi
+fi
+
+# Opportunistically sweep merged/stale sibling worktrees. Native teardowns skip
+# WorktreeRemove, so without this their merged worktrees never get cleaned. Skip
+# the worktree this session ran in, and require merge evidence before removing
+# (defensive).
 #
 # This sweep is best-effort. Its many unguarded git calls can fail transiently
 # when the harness mutates a worktree concurrently (e.g. a session resuming in
@@ -62,6 +67,5 @@ log "✓ Updated $DEFAULT_BRANCH in $REPO_ROOT"
 # exit *after* main is already updated — surfacing as a spurious "SessionEnd
 # hook error". The `|| log` both neutralizes `set -e` for this call and records
 # the failure instead of crashing the hook.
-SKIP_NAME="${CWD#"$REPO_ROOT/.claude/worktrees/"}"
-clean_stale_worktrees "$REPO_ROOT" "$DEFAULT_BRANCH" "$SKIP_NAME" "yes" \
+clean_stale_worktrees "$REPO_ROOT" "$DEFAULT_BRANCH" "$NAME" "yes" \
 	|| log "⚠ Cleanup sweep failed (non-fatal); $DEFAULT_BRANCH already updated"


### PR DESCRIPTION
Follow-up fix to #80, surfaced by interactive testing.

**Regression:** native worktree removal happens *before* `SessionEnd` fires and never triggers `WorktreeRemove`, so both remove-side cleanups silently stopped for native worktrees:
- the default branch was no longer fast-forwarded on worktree exit
- worktrees' `~/.claude/projects/` dirs accumulated as orphans

The old `SessionEnd` hook bailed at `[ -d "\$CWD" ]` — the worktree dir is already gone by the time it runs.

**Fix:** derive everything from the worktree **path string** in the payload (which survives), not the directory. Detect the worktree session via the `.claude/worktrees/` segment, ff the parent default branch from the still-present main checkout, and remove the orphaned project dir once the worktree is gone.

**Tested (2.1.195):** worktree present → ff + keep project dir; worktree deleted → ff + remove orphan; main-checkout cwd → no-op. `WorktreeRemove` kept as idempotent double-coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)