### PR TITLE
Simplify the OSC 7 cwd hook (4 events → 2, drop debug logging)

### DIFF
--- a/private_dot_claude/hooks/executable_cwd-changed-osc7.sh
+++ b/private_dot_claude/hooks/executable_cwd-changed-osc7.sh
@@ -1,27 +1,11 @@
 #!/usr/bin/env bash
-# ABOUTME: Emits OSC 7 to the user's TTY so Ghostty's working-directory
-# ABOUTME: tracking follows the agent. Wired to CwdChanged and per-turn events.
+# ABOUTME: Emits OSC 7 to the user's TTY so the terminal (Ghostty) tracks the
+# ABOUTME: agent's working directory. Wired to SessionStart and CwdChanged.
 set -euo pipefail
 
-# shellcheck source=_common.sh
-source "$(dirname "$0")/_common.sh"
-
-INPUT=$(cat)
-EVENT=$(jq -r '.hook_event_name // "unknown"' <<< "$INPUT")
-setup_logging "[osc7:$EVENT]"
-
-NEW_CWD=$(jq -r '.new_cwd // empty' <<< "$INPUT")
-[ -n "$NEW_CWD" ] || NEW_CWD="$PWD"
-
-TTY="${CLAUDE_INVOKER_TTY:-/dev/tty}"
+# CwdChanged carries new_cwd (the destination); SessionStart carries cwd.
+CWD=$(jq -r '.new_cwd // .cwd // empty')
+[ -n "$CWD" ] || CWD="$PWD"
 HOST=$(hostname -s 2>/dev/null || echo localhost)
-PARENT_CMD=$(ps -o command= -p "$PPID" 2>/dev/null | tr -s ' ' | cut -c1-80)
 
-log_quiet "pid=$$ ppid=$PPID tty=$TTY cwd=$NEW_CWD parent='$PARENT_CMD'"
-log_quiet "  payload: $(jq -c . <<< "$INPUT" 2>/dev/null || echo "$INPUT" | tr '\n' ' ')"
-log_quiet "  emit: file://$HOST$NEW_CWD"
-if [ ! -d "$NEW_CWD" ] || [ "$NEW_CWD" = "/" ]; then
-	log_quiet "  WARN: cwd missing or root — would-skip if a guard were enabled"
-fi
-
-printf '\033]7;file://%s%s\033\\' "$HOST" "$NEW_CWD" >"$TTY" 2>/dev/null || true
+printf '\033]7;file://%s%s\033\\' "$HOST" "$CWD" >"${CLAUDE_INVOKER_TTY:-/dev/tty}" 2>/dev/null || true

--- a/private_dot_claude/private_settings.json
+++ b/private_dot_claude/private_settings.json
@@ -139,20 +139,6 @@
           {
             "type": "command",
             "command": "~/.claude/hooks/user-prompt-split.sh"
-          },
-          {
-            "type": "command",
-            "command": "~/.claude/hooks/cwd-changed-osc7.sh"
-          }
-        ]
-      }
-    ],
-    "Stop": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "~/.claude/hooks/cwd-changed-osc7.sh"
           }
         ]
       }


### PR DESCRIPTION
The OSC 7 working-directory hook was wired to **four** events and logged every fire.

**Changes:**
- Wire osc7 to **SessionStart + CwdChanged** only. Those are the two moments that matter (initialize + on change). OSC 7 persists until re-emitted, so the per-turn **Stop** and **UserPromptSubmit** re-emits were redundant (confirmed against the docs — no documented per-turn cwd reset).
- **Strip the debug logging** — the script logged pid/payload/emit for every fire into `/tmp/worktree-hooks-*.log`, bloating the *worktree* hooks' log with osc7 noise. Gone, along with the `_common.sh` dependency. 28 lines → 11.
- Field logic: prefer `.new_cwd` (the CwdChanged destination), fall back to `.cwd` (SessionStart). Verified the payloads carry these.

**Verified:** CwdChanged emits the new dir (not the old), SessionStart emits the session dir, shellcheck clean, no more writes to the worktree log.

Claude Code has **no native OSC 7** emission (researched), so the hook stays — just leaner. If the terminal cwd ever drifts after shell commands, re-add a Stop emit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)