### PR TITLE
osc7: re-add the Stop emit (CwdChanged misses EnterWorktree)

### DIFF
--- a/private_dot_claude/hooks/executable_cwd-changed-osc7.sh
+++ b/private_dot_claude/hooks/executable_cwd-changed-osc7.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 # ABOUTME: Emits OSC 7 to the user's TTY so the terminal (Ghostty) tracks the
-# ABOUTME: agent's working directory. Wired to SessionStart and CwdChanged.
+# ABOUTME: agent's working directory. Wired to SessionStart, CwdChanged, and Stop.
 set -euo pipefail
 
-# CwdChanged carries new_cwd (the destination); SessionStart carries cwd.
+# CwdChanged carries new_cwd (the destination); SessionStart/Stop carry cwd (and
+# fall through to $PWD). Stop re-asserts at each turn end, catching cwd changes
+# like EnterWorktree that CwdChanged does not propagate to the terminal.
 CWD=$(jq -r '.new_cwd // .cwd // empty')
 [ -n "$CWD" ] || CWD="$PWD"
 HOST=$(hostname -s 2>/dev/null || echo localhost)

--- a/private_dot_claude/private_settings.json
+++ b/private_dot_claude/private_settings.json
@@ -153,6 +153,16 @@
         ]
       }
     ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/cwd-changed-osc7.sh"
+          }
+        ]
+      }
+    ],
     "SubagentStart": [
       {
         "hooks": [


### PR DESCRIPTION
Fix for a regression from #84. Dropping the per-turn re-emit broke cwd tracking for **EnterWorktree**: switching into a worktree mid-turn doesn't propagate to the terminal via `CwdChanged`, so without the end-of-turn `Stop` re-assert, Ghostty stayed on the launch dir (verified: new tab opened in the repo root, not the worktree).

`Stop` emits the session cwd (via `$PWD`) after every turn — that's what actually carried these changes to the terminal. It was **not** redundant.

- re-add `Stop` → wiring is now SessionStart + CwdChanged + Stop
- `UserPromptSubmit` stays dropped (Stop-after-turn covers the same case)
- debug logging stays stripped (that part of #84 was fine)

🤖 Generated with [Claude Code](https://claude.com/claude-code)