### PR TITLE
osc7: emit full hostname (Ghostty rejects the short name)

### DIFF
--- a/private_dot_claude/hooks/executable_cwd-changed-osc7.sh
+++ b/private_dot_claude/hooks/executable_cwd-changed-osc7.sh
@@ -8,6 +8,9 @@ set -euo pipefail
 # like EnterWorktree that CwdChanged does not propagate to the terminal.
 CWD=$(jq -r '.new_cwd // .cwd // empty')
 [ -n "$CWD" ] || CWD="$PWD"
-HOST=$(hostname -s 2>/dev/null || echo localhost)
+# Full hostname, not the short name: Ghostty drops OSC 7 whose host doesn't match
+# its gethostname() ("OSC 7 host must be local"), and on macOS that is the full
+# name (e.g. host.local) — the same value Ghostty's own shell integration sends.
+HOST=$(hostname 2>/dev/null || echo localhost)
 
 printf '\033]7;file://%s%s\033\\' "$HOST" "$CWD" >"${CLAUDE_INVOKER_TTY:-/dev/tty}" 2>/dev/null || true


### PR DESCRIPTION
**Root cause of the cwd-tracking failure.** Ghostty drops any OSC 7 whose host doesn't match its `gethostname()` (logs `OSC 7 host must be local`) and freezes the pane cwd. On macOS that's the **full** name (`host.local`) — the same value Ghostty's own shell integration sends via `$HOST`. The hook emitted `hostname -s` (short name `lemon` vs Ghostty's `lemon.local`), so **every emit was silently rejected** — the hook never worked for cwd changes; only Ghostty's shell integration set the initial cwd at launch.

Fix: emit `hostname` (full) instead of `hostname -s`.

**Verified live:** emitting the full host while a `sleep` held the prompt (no shell re-report to clobber it) moved Ghostty's cwd to the target; the short host did not. With #85's `Stop` re-assert, EnterWorktree tracking now works end to end.

Config note: `tab-/split-inherit-working-directory = true` (windows intentionally don't inherit), so tabs/splits follow the pane cwd once the emit is accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)